### PR TITLE
Support v prefix for tags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,9 @@ runs:
         elif [[ $GITHUB_REF == refs/heads/dev ]]; then
           TAGS="dev-${GITHUB_SHA::8}"
           PUSH="true"
+        elif [[ $GITHUB_REF == refs/tags/v* ]]; then
+          TAGS="${GITHUB_REF:11}"
+          PUSH="true"
         elif [[ $GITHUB_REF == refs/tags/* ]]; then
           TAGS="${GITHUB_REF:10}"
           PUSH="true"


### PR DESCRIPTION
... since some repos use that (and I still prefer that to differentiate between tag intentions).