### PR TITLE
add guard to prevent creation of non existend yaml path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -125,24 +125,32 @@ runs:
           if [[ $GITHUB_REF == refs/heads/master ]] || [[ $GITHUB_REF == refs/heads/main ]]; then
             echo "Run update for STAGE"
             while IFS= read -r line; do
+              echo "Check if path $line exists and get old current version"
+              ../gitops/yq r -e $line
               echo "Run update $line ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.tag }}"
               ../gitops/yq w -i $line ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.tag }}
             done <<< "${{ inputs.gitopsstage }}"
           elif [[ $GITHUB_REF == refs/heads/dev ]]; then
             echo "Run update for DEV"
             while IFS= read -r line; do
+              echo "Check if path $line exists and get old current version"
+              ../gitops/yq r -e $line
               echo "Run update $line ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.tag }}"
               ../gitops/yq w -i $line ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.tag }}
             done <<< "${{ inputs.gitopsdev }}"
           elif [[ $GITHUB_REF == refs/tags/* ]]; then
             echo "Run update for PROD"
             while IFS= read -r line; do
+              echo "Check if path $line exists and get old current version"
+              ../gitops/yq r -e $line
               echo "Run update $line ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.tag }}"
               ../gitops/yq w -i $line ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.tag }}
             done <<< "${{ inputs.gitopsprod }}"
           else
             echo "Simulate update for DEV"
             while IFS= read -r line; do
+              echo "Check if path $line exists and get old current version"
+              ../gitops/yq r -e $line
               echo "Run update $line ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.tag }}"
               ../gitops/yq w -i $line ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.tag }}
             done <<< "${{ inputs.gitopsdev }}"


### PR DESCRIPTION
check if given yaml path exits

have a look at https://github.com/Staffbase/pacman/runs/1531674528?check_suite_focus=true where I added the typo (template**s**)
there is says:
```
Check if path clusters/customization/dev/build/pacman/pacman-cr.yaml spec.templateS.spec.containers.pacman.image exists and get old current version
Error: No matches found
Error: Process completed with exit code 1.
```