### PR TITLE
Pull again right before pushing to mops

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -158,6 +158,7 @@ runs:
 
           if [[ ${{ steps.preparation.outputs.push }} == "true" ]]; then
             git add . && git commit -m "Release ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.tag }}"
+            git pull --rebase https://${{ inputs.gitopsuser }}:${{ inputs.gitopstoken }}@github.com/${{ inputs.gitopsorganization }}/${{ inputs.gitopsrepository }}.git # in case there was another push in the meantime
             git push https://${{ inputs.gitopsuser }}:${{ inputs.gitopstoken }}@github.com/${{ inputs.gitopsorganization }}/${{ inputs.gitopsrepository }}.git
           fi
         fi


### PR DESCRIPTION
It happened to me twice already in my monorepo that new changes arrived between cloning and pushing

```
Cloning into '.github/mops'...
Repository Staffbase/mops was cloned successfully 
Run update for DEV
Check if path clusters/customization/dev/main-de1/dwh-pipeline/dwh-tokenizer-cr.yaml spec.template.spec.containers.tokenizer.image exists and get old current version
registry.staffbase.com/private/dwh-tokenizer:dev-fffbfed4
Run update clusters/customization/dev/main-de1/dwh-pipeline/dwh-tokenizer-cr.yaml spec.template.spec.containers.tokenizer.image registry.staffbase.com/private/dwh-tokenizer:dev-f4a3bbf8
[master a4fbffbb2] Release registry.staffbase.com/private/dwh-tokenizer:dev-f4a3bbf8
 1 file changed, 1 insertion(+), 1 deletion(-)
To https://github.com/Staffbase/mops.git
 ! [rejected]            master -> master (fetch first)
error: failed to push some refs to 'https://github.com/Staffbase/mops.git'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Error: Process completed with exit code 1.
```