### PR TITLE
add option to push all docker tags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -108,7 +108,7 @@ runs:
           fi
 
           if [[ ${{ steps.preparation.outputs.push }} == "true" ]]; then
-            docker push ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}
+            docker push --all-tags ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}
           fi
         fi
 


### PR DESCRIPTION
Docker cli updated there default behavior and now need an option to push all tags otherwise it will fallback to "latest".
https://github.com/docker/cli/pull/2220

https://github.com/Staffbase/apps-control/runs/1878817906?check_suite_focus=true