### PR TITLE
Add catalog-info.yaml for Backstage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @Staffbase/diablo

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,10 +2,11 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: gitops-github-action
+  description: Used for our GitOps workflow. Build and push the Docker image and deploys to our Kubernetes clusters.
   annotations:
     github.com/project-slug: Staffbase/gitops-github-action
   tags:
     - infrastructure
 spec:
-  type: service
+  type: other
   lifecycle: production


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the [Staffbase Backstage App software catalog](https://backstage.staffbase.com).

After this pull request is merged, the component will become available.

**To make ownership visible add a [CODEOWNERS](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) file to this repo.**

Feel free to make changes to the file. For more information, read about the [descriptor format of catalog entities](https://backstage.io/docs/features/software-catalog/descriptor-format).

If you want to have additional information about Backstage, do not hestiate to get in contact with @Staffbase/diablo.