### PR TITLE
BREAKING CHANGE: Change tag when using main branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,9 +68,13 @@ runs:
       id: preparation
       shell: bash
       run: |
-        if [[ $GITHUB_REF == refs/heads/master ]] || [[ $GITHUB_REF == refs/heads/main ]]; then
+        if [[ $GITHUB_REF == refs/heads/master ]]; then
           TAG="master-${GITHUB_SHA::8}"
           LATEST="master"
+          PUSH="true"
+        elif [[ $GITHUB_REF == refs/heads/main ]]; then
+          TAG="main-${GITHUB_SHA::8}"
+          LATEST="main"
           PUSH="true"
         elif [[ $GITHUB_REF == refs/heads/dev ]]; then
           TAG="dev-${GITHUB_SHA::8}"


### PR DESCRIPTION
I would like to discuss this change.
When a repository uses the `main` branch then (from my point of view) the docker image should reflect this as well.

Since this will be a Breaking Change for all repositories who are using this already what do you think about this?

### Proposal

1. merging this to the `main` branch
2. creating a new tag `v2`
