### PR TITLE
Use official docker build push action

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ jobs:
           dockerpassword: ${{ secrets.DOCKER_PASSWORD }}
           # This is the name of the Docker image for your service.
           dockerimage: private/diablo-redbook
+          # List of build-time variables
+          dockerbuildargs: "ARG1='one',ARG2='two'"
+          # Sets the target stage to build
+          dockerbuildtarget: "runtime"
           # The additional arguments you need to build the docker image
-          dockeradditionalbuildparams: "--target runtime --build-arg ARG1='one' --build-arg ARG2='two'"
           gitopstoken: ${{ secrets.GITOPS_TOKEN }}
           # The gitopsdev, gitopsstage and gitopsprod values are used to specify which files including the YAML path which should be updated with the new image.
           # ATTENTION 1: You must use |- to remove the final newline in the string, otherwise the GitHub Action will fail.
@@ -66,22 +69,24 @@ jobs:
 
 ## Inputs
 
-| Name | Description | Default |
-| ---- | ----------- | ------- |
-| `dockerenabled` | Build and push the Docker Image | `true` |
-| `dockerregistry` | Docker Registry | `registry.staffbase.com`|
-| `dockerimage` | Docker Image | |
-| `dockerusername` | Username for the Docker Registry | |
-| `dockerpassword` | Password for the Docker Registry | |
-| `dockerfile` | Dockerfile | `./Dockerfile` |
-| `dockeradditionalbuildparams` | List of Docker Build Parameters like: "--target runtime --build-arg ARG1=one --build-arg ARG2=two" | |
-| `gitopsenabled` | Update the manifest files in the GitOps repository | `true` |
-| `gitopsorganization` | GitHub Organization for GitOps | `Staffbase` |
-| `gitopsrepository` | GitHub Repository for GitOps | `mops` |
-| `gitopsuser` | GitHub User for GitOps | `Staffbot` |
-| `gitopsemail` | GitHub User for GitOps | `staffbot@staffbase.com` |
-| `gitopstoken` | GitHub Token for GitOps | |
-| `gitopsdev` | Files which should be updated by the GitHub Action for DEV | |
-| `gitopsstage` | Files which should be updated by the GitHub Action for STAGE | |
-| `gitopsprod` | Files which should be updated by the GitHub Action for PROD | |
-| `workingdirectory` | The directory in which the GitOps action should be executed. The dockerfile variable should be relative to working directory. | `.` |
+| Name                          | Description                                                                                                                   | Default                  |
+|-------------------------------|-------------------------------------------------------------------------------------------------------------------------------|--------------------------|
+| `dockerenabled`               | Build and push the Docker Image                                                                                               | `true`                   |
+| `dockerregistry`              | Docker Registry                                                                                                               | `registry.staffbase.com` |
+| `dockerimage`                 | Docker Image                                                                                                                  |                          |
+| `dockerusername`              | Username for the Docker Registry                                                                                              |                          |
+| `dockerpassword`              | Password for the Docker Registry                                                                                              |                          |
+| `dockerfile`                  | Dockerfile                                                                                                                    | `./Dockerfile`           |
+| `dockeradditionalbuildparams` | List of Docker Build Parameters like: "--target runtime --build-arg ARG1=one --build-arg ARG2=two"                            |                          |
+| `dockerbuildargs`             | List of build-time variables like: "ARG1=one,ARG2=two"                                                                        |                          |
+| `dockerbuildtarget`           | Sets the target stage to build like: "runtime"                                                                                |                          |
+| `gitopsenabled`               | Update the manifest files in the GitOps repository                                                                            | `true`                   |
+| `gitopsorganization`          | GitHub Organization for GitOps                                                                                                | `Staffbase`              |
+| `gitopsrepository`            | GitHub Repository for GitOps                                                                                                  | `mops`                   |
+| `gitopsuser`                  | GitHub User for GitOps                                                                                                        | `Staffbot`               |
+| `gitopsemail`                 | GitHub User for GitOps                                                                                                        | `staffbot@staffbase.com` |
+| `gitopstoken`                 | GitHub Token for GitOps                                                                                                       |                          |
+| `gitopsdev`                   | Files which should be updated by the GitHub Action for DEV                                                                    |                          |
+| `gitopsstage`                 | Files which should be updated by the GitHub Action for STAGE                                                                  |                          |
+| `gitopsprod`                  | Files which should be updated by the GitHub Action for PROD                                                                   |                          |
+| `workingdirectory`            | The directory in which the GitOps action should be executed. The dockerfile variable should be relative to working directory. | `.`                      |

--- a/action.yml
+++ b/action.yml
@@ -133,6 +133,7 @@ runs:
         target: ${{ inputs.dockerbuildtarget }}
         build-args: ${{ inputs.dockerbuildargs }}
         tags: ${{ steps.preparation.outputs.tag_list }}
+        platforms: linux/amd64
         cache-from: type=gha
         cache-to: type=gha,mode=max
 

--- a/action.yml
+++ b/action.yml
@@ -124,10 +124,11 @@ runs:
 
     - name: Build
       id: docker_build
+      if: ${{ inputs.dockerenabled }} == "true"
       uses: docker/build-push-action@v2
       with:
         context: .
-        push: true
+        push: ${{ steps.preparation.outputs.push }}
         file: ${{ inputs.dockerfile }}
         target: ${{ inputs.dockerbuildtarget }}
         build-args: ${{ inputs.dockerbuildargs }}

--- a/action.yml
+++ b/action.yml
@@ -136,38 +136,6 @@ runs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
-#    - name: Push the Docker Image
-#      shell: bash
-#      working-directory: ${{ inputs.workingdirectory }}
-#      run: |
-#        if [[ ${{ inputs.dockerenabled }} == "true" ]]; then
-#          echo The working directory is $(pwd)
-#          echo '${{ inputs.dockerpassword }}' | docker login ${{ inputs.dockerregistry }} -u '${{ inputs.dockerusername }}' --password-stdin
-#
-#          if [[ ${{ steps.preparation.outputs.push }} == "true" ]]; then
-#            docker push --all-tags ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}
-#          fi
-#        fi
-
-#    - name: Build and Push the Docker Image
-#      shell: bash
-#      working-directory: ${{ inputs.workingdirectory }}
-#      run: |
-#        if [[ ${{ inputs.dockerenabled }} == "true" ]]; then
-#          echo The working directory is $(pwd)
-#          echo '${{ inputs.dockerpassword }}' | docker login ${{ inputs.dockerregistry }} -u '${{ inputs.dockerusername }}' --password-stdin
-#
-#          docker build ${{ inputs.dockeradditionalbuildparams }} -f ${{ inputs.dockerfile }} -t ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.tag }} .
-#
-#          if [[ ! -z "${{ steps.preparation.outputs.latest }}" ]]; then
-#            docker tag ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.tag }} ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.latest }}
-#          fi
-#
-#          if [[ ${{ steps.preparation.outputs.push }} == "true" ]]; then
-#            docker push --all-tags ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}
-#          fi
-#        fi
-
     - name: Update Docker Image in Repository
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -103,6 +103,9 @@ runs:
         echo ::set-output name=latest::${LATEST}
         echo ::set-output name=push::${PUSH}
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
     - name: Build
       id: docker_build
       uses: docker/build-push-action@v2
@@ -112,6 +115,8 @@ runs:
         file: ${{ inputs.dockerfile }}
         target: ${{ inputs.dockeradditionalbuildparams }}
         tags: ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.tag }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Push the Docker Image
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -99,6 +99,12 @@ runs:
           PUSH="false"
         fi
 
+        TAG_LIST="${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${TAG}"
+        if [[ ! -z "${LATEST}" ]]; then
+          TAG_LIST+=",${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${LATEST}"
+        fi
+
+        echo ::set-output name=tag_list::${TAG_LIST}
         echo ::set-output name=tag::${TAG}
         echo ::set-output name=latest::${LATEST}
         echo ::set-output name=push::${PUSH}
@@ -106,34 +112,37 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
+    - name: Login to Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ inputs.dockerregistry }}
+        username: ${{ inputs.dockerusername }}
+        password: ${{ inputs.dockerpassword }}
+
     - name: Build
       id: docker_build
       uses: docker/build-push-action@v2
       with:
         context: .
-        push: false
+        push: true
         file: ${{ inputs.dockerfile }}
         target: ${{ inputs.dockeradditionalbuildparams }}
-        tags: ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.tag }}
+        tags: ${{ steps.preparation.outputs.tag_list }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
-    - name: Push the Docker Image
-      shell: bash
-      working-directory: ${{ inputs.workingdirectory }}
-      run: |
-        if [[ ${{ inputs.dockerenabled }} == "true" ]]; then
-          echo The working directory is $(pwd)
-          echo '${{ inputs.dockerpassword }}' | docker login ${{ inputs.dockerregistry }} -u '${{ inputs.dockerusername }}' --password-stdin
-
-          if [[ ! -z "${{ steps.preparation.outputs.latest }}" ]]; then
-            docker tag ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.tag }} ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.latest }}
-          fi
-
-          if [[ ${{ steps.preparation.outputs.push }} == "true" ]]; then
-            docker push --all-tags ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}
-          fi
-        fi
+#    - name: Push the Docker Image
+#      shell: bash
+#      working-directory: ${{ inputs.workingdirectory }}
+#      run: |
+#        if [[ ${{ inputs.dockerenabled }} == "true" ]]; then
+#          echo The working directory is $(pwd)
+#          echo '${{ inputs.dockerpassword }}' | docker login ${{ inputs.dockerregistry }} -u '${{ inputs.dockerusername }}' --password-stdin
+#
+#          if [[ ${{ steps.preparation.outputs.push }} == "true" ]]; then
+#            docker push --all-tags ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}
+#          fi
+#        fi
 
 #    - name: Build and Push the Docker Image
 #      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -22,8 +22,11 @@ inputs:
     description: 'Dockerfile'
     required: true
     default: './Dockerfile'
-  dockeradditionalbuildparams:
-    description: 'List of Docker Build Parameters like: "--target runtime --build-arg ARG1=one --build-arg ARG2=two"'
+  dockerbuildargs:
+    description: "List of build-time variables"
+    required: false
+  dockerbuildtarget:
+    description: "Sets the target stage to build"
     required: false
   gitopsenabled:
     description: 'Update manifest files in the GitOps repository'
@@ -126,7 +129,8 @@ runs:
         context: .
         push: true
         file: ${{ inputs.dockerfile }}
-        target: ${{ inputs.dockeradditionalbuildparams }}
+        target: ${{ inputs.dockerbuildtarget }}
+        build-args: ${{ inputs.dockerbuildargs }}
         tags: ${{ steps.preparation.outputs.tag_list }}
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/action.yml
+++ b/action.yml
@@ -103,15 +103,23 @@ runs:
         echo ::set-output name=latest::${LATEST}
         echo ::set-output name=push::${PUSH}
 
-    - name: Build and Push the Docker Image
+    - name: Build
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: false
+        file: ${{ inputs.dockerfile }}
+        target: ${{ inputs.dockeradditionalbuildparams }}
+        tags: ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.tag }}
+
+    - name: Push the Docker Image
       shell: bash
       working-directory: ${{ inputs.workingdirectory }}
       run: |
         if [[ ${{ inputs.dockerenabled }} == "true" ]]; then
           echo The working directory is $(pwd)
           echo '${{ inputs.dockerpassword }}' | docker login ${{ inputs.dockerregistry }} -u '${{ inputs.dockerusername }}' --password-stdin
-
-          docker build ${{ inputs.dockeradditionalbuildparams }} -f ${{ inputs.dockerfile }} -t ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.tag }} .
 
           if [[ ! -z "${{ steps.preparation.outputs.latest }}" ]]; then
             docker tag ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.tag }} ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.latest }}
@@ -121,6 +129,25 @@ runs:
             docker push --all-tags ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}
           fi
         fi
+
+#    - name: Build and Push the Docker Image
+#      shell: bash
+#      working-directory: ${{ inputs.workingdirectory }}
+#      run: |
+#        if [[ ${{ inputs.dockerenabled }} == "true" ]]; then
+#          echo The working directory is $(pwd)
+#          echo '${{ inputs.dockerpassword }}' | docker login ${{ inputs.dockerregistry }} -u '${{ inputs.dockerusername }}' --password-stdin
+#
+#          docker build ${{ inputs.dockeradditionalbuildparams }} -f ${{ inputs.dockerfile }} -t ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.tag }} .
+#
+#          if [[ ! -z "${{ steps.preparation.outputs.latest }}" ]]; then
+#            docker tag ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.tag }} ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}:${{ steps.preparation.outputs.latest }}
+#          fi
+#
+#          if [[ ${{ steps.preparation.outputs.push }} == "true" ]]; then
+#            docker push --all-tags ${{ inputs.dockerregistry }}/${{ inputs.dockerimage }}
+#          fi
+#        fi
 
     - name: Update Docker Image in Repository
       shell: bash


### PR DESCRIPTION
This is my proposal of using official actions for docker login, build and push.
This allows us to speed up or ci pipelines due to caching of the images. For us this change gain up to 50% speed on the deployment step.

It is arguable to split this whole action up into its parts to be able to just use everything from the original source and be able to use every feature from those. This would be a change I don't want to do as should be something discussed and decided in diablo, I guess.

As input parameters are changing I would release a v3. There I might need help to write a proper migration guide which is shown via dependabot.

**Example:**
before: https://github.com/Staffbase/pickle-rick/runs/4817457094?check_suite_focus=true
after: https://github.com/Staffbase/pickle-rick/runs/4865195476?check_suite_focus=true