### PR TITLE
RE-0000: fix step condition 🐛

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -124,7 +124,7 @@ runs:
 
     - name: Build
       id: docker_build
-      if: ${{ inputs.dockerenabled }} == "true"
+      if: ${{ inputs.dockerenabled == "true" }}
       uses: docker/build-push-action@v2
       with:
         context: .


### PR DESCRIPTION
The condition was not correctly evaluated, as the actual `==` is not in a template-block for GHA to evaluate.

example (of GHA runner with debug logs and parameter set to `false`):
```
##[debug]Node Action run completed with exit code 0
##[debug]Finished: run
##[debug]Evaluating condition for step: 'run'
##[debug]Evaluating: (success() && format('{0} == "true"', inputs.dockerenabled))
##[debug]Evaluating And:
##[debug]..Evaluating success:
##[debug]..=> true
##[debug]..Evaluating format:
##[debug]....Evaluating String:
##[debug]....=> '{0} == "true"'
##[debug]....Evaluating Index:
##[debug]......Evaluating inputs:
##[debug]......=> Object
##[debug]......Evaluating String:
##[debug]......=> 'dockerenabled'
##[debug]....=> 'false'
##[debug]..=> 'false == "true"'
##[debug]=> 'false == "true"'
##[debug]Expanded: (true && 'false == "true"')
##[debug]Result: 'false == "true"'
##[debug]Starting: run
```