### PR TITLE
RE-0000: fix condition 🐛

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -124,7 +124,7 @@ runs:
 
     - name: Build
       id: docker_build
-      if: ${{ inputs.dockerenabled == "true" }}
+      if: inputs.dockerenabled == 'true'
       uses: docker/build-push-action@v2
       with:
         context: .


### PR DESCRIPTION
From GitHub docs at https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif:

> When you use expressions in an if conditional, you may omit the expression syntax (`${{ }}`) because GitHub automatically evaluates the if conditional as an expression. For more information, see "[Expressions](https://docs.github.com/en/actions/learn-github-actions/expressions)."

Also, the `true` has to be single-quoted.

Error: 

![image](https://user-images.githubusercontent.com/45522563/150658188-4b1a4181-7820-4a78-a76a-39388c4e3052.png)

We had some rruns this was working with, maybe GH was caching there 🤷🏼‍♂️ 