### PR TITLE
:fire: remove deprecated set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -101,10 +101,10 @@ runs:
           TAG_LIST+=",${{ inputs.docker-registry }}/${{ inputs.docker-image }}:${LATEST}"
         fi
 
-        echo ::set-output name=tag_list::${TAG_LIST}
-        echo ::set-output name=tag::${TAG}
-        echo ::set-output name=latest::${LATEST}
-        echo ::set-output name=push::${PUSH}
+        echo "tag_list=$TAG_LIST" >> $GITHUB_OUTPUT
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
+        echo "latest=$LATEST" >> $GITHUB_OUTPUT
+        echo "push=$PUSH" >> $GITHUB_OUTPUT
 
     - name: Set up Docker Buildx
       if: inputs.docker-username != '' && inputs.docker-password != ''


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

<!-- Please describe your pull request -->

- remove `set-output` method ([deprecation notice](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/))
- [using new method to set output for an GitHub Action](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter)

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [x] Review the [Contributing Guideline](../blob/master/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
