### PR TITLE
:art: Retry push attempts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -146,6 +146,12 @@ runs:
       working-directory: .github/${{ inputs.gitops-repository }}
       shell: bash
       run: |
+        push_to_gitops_repo () {
+          # In case there was another push in the meantime, we pull it again
+          git pull --rebase https://${{ inputs.gitops-user }}:${{ inputs.gitops-token }}@github.com/${{ inputs.gitops-organization }}/${{ inputs.gitops-repository }}.git
+          git push https://${{ inputs.gitops-user }}:${{ inputs.gitops-token }}@github.com/${{ inputs.gitops-organization }}/${{ inputs.gitops-repository }}.git
+        }
+
         commit_changes () {
           if [[ ${{ steps.preparation.outputs.push }} == "true" ]]; then
             git add .
@@ -157,9 +163,9 @@ runs:
             fi
 
             git commit -m "Release ${{ inputs.docker-registry }}/${{ inputs.docker-image }}:${{ steps.preparation.outputs.tag }}"
-            # In case there was another push in the meantime, we pull it again
-            git pull --rebase https://${{ inputs.gitops-user }}:${{ inputs.gitops-token }}@github.com/${{ inputs.gitops-organization }}/${{ inputs.gitops-repository }}.git
-            git push https://${{ inputs.gitops-user }}:${{ inputs.gitops-token }}@github.com/${{ inputs.gitops-organization }}/${{ inputs.gitops-repository }}.git
+
+            # retry push attempt since rejections can still happen (even with pull before push)
+            push_to_gitops_repo || push_to_gitops_repo || push_to_gitops_repo
           fi
         }
 


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

Even with pull before push in place, rejections can occur. With the retry, this chance should be minimized.


```sh
Current branch main is up to date.
To https://github.com/Staffbase/mops.git
 ! [rejected]        main -> main (fetch first)
error: failed to push some refs to 'https://github.com/Staffbase/***.git'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Error: Process completed with exit code 1.
```

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [x] Review the [Contributing Guideline](../blob/master/CONTRIBUTING.md) and sign CLA
- [x] Reference relevant issue(s) and close them after merging
