### PR TITLE
Switch to Staffbase Artifactory as new default docker registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ jobs:
       - name: GitOps (build, push and deploy a new Docker image)
         uses: Staffbase/gitops-github-action@v4
         with:
-          docker-username: ${{ secrets.DOCKER_USERNAME }}
-          docker-password: ${{ secrets.DOCKER_PASSWORD }}
+          docker-username: ${{ secrets.ARTIFACTORY_USERNAME }}
+          docker-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
           docker-image: private/diablo-redbook
           gitops-token: ${{ secrets.GITOPS_TOKEN }}
           gitops-dev: |-
@@ -68,8 +68,8 @@ jobs:
       - name: GitOps (build and push a new Docker image)
         uses: Staffbase/gitops-github-action@v4
         with:
-          docker-username: ${{ secrets.DOCKER_USERNAME }}
-          docker-password: ${{ secrets.DOCKER_PASSWORD }}
+          docker-username: ${{ secrets.ARTIFACTORY_USERNAME }}
+          docker-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
           docker-image: private/diablo-redbook
 ```
 
@@ -107,7 +107,7 @@ jobs:
 
 | Name                  | Description                                                                                                                    | Default                  |
 |-----------------------|--------------------------------------------------------------------------------------------------------------------------------|--------------------------|
-| `docker-registry`     | Docker Registry                                                                                                                | `registry.staffbase.com` |
+| `docker-registry`     | Docker Registry                                                                                                                | `staffbase.jfrog.io`     |
 | `docker-image`        | Docker Image                                                                                                                   |                          |
 | `docker-username`     | Username for the Docker Registry                                                                                               |                          |
 | `docker-password`     | Password for the Docker Registry                                                                                               |                          |

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   docker-registry:
     description: 'Docker Registry'
     required: true
-    default: 'registry.staffbase.com'
+    default: 'staffbase.jfrog.io'
   docker-image:
     description: 'Docker Image'
     required: true


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [x] Enhancement / new feature

### Description

This switches the default registry from registry.staffbase.com to staffbase.jfrog.io which is our new prefered way of releasing images.

The idea would be to release a new version of this action and have repositories switch gradually.

When updating there is also the need to switch the following:

- docker-image -> replace `/private` with `/sb-images`
- docker-username -> replace `DOCKER_USERNAME` with `ARTIFACTORY_USERNAME`
- docker-password -> replace `DOCKER_PASSWORD`with `ARTIFACTORY_PASSWORD`
- docker-registry -> if set replace `registry.staffbase.com` with `staffbase.jfrog.io`

The new secrets are available as a company-wide Github secret or environment variable.

Clusters are already prepared for the change and should be able to pull images from the new registry.

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Review the [Contributing Guideline](../blob/master/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
