### PR TITLE
add possibility to pass docker build secrets to the build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,24 +105,26 @@ jobs:
 
 ## Inputs
 
-| Name                  | Description                                                                                                                    | Default                  |
-|-----------------------|--------------------------------------------------------------------------------------------------------------------------------|--------------------------|
-| `docker-registry`     | Docker Registry                                                                                                                | `staffbase.jfrog.io`     |
-| `docker-image`        | Docker Image                                                                                                                   |                          |
-| `docker-username`     | Username for the Docker Registry                                                                                               |                          |
-| `docker-password`     | Password for the Docker Registry                                                                                               |                          |
-| `docker-file`         | Dockerfile                                                                                                                     | `./Dockerfile`           |
-| `docker-build-args`   | List of build-time variables                                                                                                   |                          |
-| `docker-build-target` | Sets the target stage to build like: "runtime"                                                                                 |                          |
-| `gitops-organization` | GitHub Organization for GitOps                                                                                                 | `Staffbase`              |
-| `gitops-repository`   | GitHub Repository for GitOps                                                                                                   | `mops`                   |
-| `gitops-user`         | GitHub User for GitOps                                                                                                         | `Staffbot`               |
-| `gitops-email`        | GitHub Email for GitOps                                                                                                        | `staffbot@staffbase.com` |
-| `gitops-token`        | GitHub Token for GitOps                                                                                                        |                          |
-| `gitops-dev`          | Files which should be updated by the GitHub Action for DEV, must be relative to the root of the GitOps repository              |                          |
-| `gitops-stage`        | Files which should be updated by the GitHub Action for STAGE, must be relative to the root of the GitOps repository            |                          |
-| `gitops-prod`         | Files which should be updated by the GitHub Action for PROD, must be relative to the root of the GitOps repository             |                          |
-| `working-directory`   | The directory in which the GitOps action should be executed. The docker-file variable should be relative to working directory. | `.`                      |
+| Name                        | Description                                                                                                                    | Default                  |
+|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------|--------------------------|
+| `docker-registry`           | Docker Registry                                                                                                                | `staffbase.jfrog.io`     |
+| `docker-image`              | Docker Image                                                                                                                   |                          |
+| `docker-username`           | Username for the Docker Registry                                                                                               |                          |
+| `docker-password`           | Password for the Docker Registry                                                                                               |                          |
+| `docker-file`               | Dockerfile                                                                                                                     | `./Dockerfile`           |
+| `docker-build-args`         | List of build-time variables                                                                                                   |                          |
+| `docker-build-secrets`      | List of secrets to expose to the build (e.g., key=string, GIT_AUTH_TOKEN=mytoken)                                              |                          |
+| `docker-build-secret-files` | List of secret files to expose to the build (e.g., key=filename, MY_SECRET=./secret.txt)                                       |                          |
+| `docker-build-target`       | Sets the target stage to build like: "runtime"                                                                                 |                          |
+| `gitops-organization`       | GitHub Organization for GitOps                                                                                                 | `Staffbase`              |
+| `gitops-repository`         | GitHub Repository for GitOps                                                                                                   | `mops`                   |
+| `gitops-user`               | GitHub User for GitOps                                                                                                         | `Staffbot`               |
+| `gitops-email`              | GitHub Email for GitOps                                                                                                        | `staffbot@staffbase.com` |
+| `gitops-token`              | GitHub Token for GitOps                                                                                                        |                          |
+| `gitops-dev`                | Files which should be updated by the GitHub Action for DEV, must be relative to the root of the GitOps repository              |                          |
+| `gitops-stage`              | Files which should be updated by the GitHub Action for STAGE, must be relative to the root of the GitOps repository            |                          |
+| `gitops-prod`               | Files which should be updated by the GitHub Action for PROD, must be relative to the root of the GitOps repository             |                          |
+| `working-directory`         | The directory in which the GitOps action should be executed. The docker-file variable should be relative to working directory. | `.`                      |
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,12 @@ inputs:
   docker-build-args:
     description: "List of build-time variables"
     required: false
+  docker-build-secrets:
+    description: "List of secrets to expose to the build (e.g., key=string, GIT_AUTH_TOKEN=mytoken)"
+    required: false
+  docker-build-secret-files:
+    description: "List of secret files to expose to the build (e.g., key=filename, MY_SECRET=./secret.txt)"
+    required: false
   docker-build-target:
     description: "Sets the target stage to build"
     required: false
@@ -129,6 +135,8 @@ runs:
         target: ${{ inputs.docker-build-target }}
         build-args: ${{ inputs.docker-build-args }}
         tags: ${{ steps.preparation.outputs.tag_list }}
+        secrets: ${{ inputs.docker-build-secrets }}
+        secret-files: ${{ inputs.docker-build-secret-files }}
         platforms: linux/amd64
         cache-from: type=gha
         cache-to: type=gha,mode=max


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

<!-- Please describe your pull request -->
Add possibility to pass secrets to docker build. This is necessary to implement this: https://github.com/Staffbase/play-store-connect-service/pull/92

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [x] Review the [Contributing Guideline](../blob/master/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
