### PR TITLE
✨ Add Option to configure provenance attestations

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,26 +105,27 @@ jobs:
 
 ## Inputs
 
-| Name                        | Description                                                                                                                    | Default                  |
-|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------|--------------------------|
-| `docker-registry`           | Docker Registry                                                                                                                | `staffbase.jfrog.io`     |
-| `docker-image`              | Docker Image                                                                                                                   |                          |
-| `docker-username`           | Username for the Docker Registry                                                                                               |                          |
-| `docker-password`           | Password for the Docker Registry                                                                                               |                          |
-| `docker-file`               | Dockerfile                                                                                                                     | `./Dockerfile`           |
-| `docker-build-args`         | List of build-time variables                                                                                                   |                          |
-| `docker-build-secrets`      | List of secrets to expose to the build (e.g., key=string, GIT_AUTH_TOKEN=mytoken)                                              |                          |
-| `docker-build-secret-files` | List of secret files to expose to the build (e.g., key=filename, MY_SECRET=./secret.txt)                                       |                          |
-| `docker-build-target`       | Sets the target stage to build like: "runtime"                                                                                 |                          |
-| `gitops-organization`       | GitHub Organization for GitOps                                                                                                 | `Staffbase`              |
-| `gitops-repository`         | GitHub Repository for GitOps                                                                                                   | `mops`                   |
-| `gitops-user`               | GitHub User for GitOps                                                                                                         | `Staffbot`               |
-| `gitops-email`              | GitHub Email for GitOps                                                                                                        | `staffbot@staffbase.com` |
-| `gitops-token`              | GitHub Token for GitOps                                                                                                        |                          |
-| `gitops-dev`                | Files which should be updated by the GitHub Action for DEV, must be relative to the root of the GitOps repository              |                          |
-| `gitops-stage`              | Files which should be updated by the GitHub Action for STAGE, must be relative to the root of the GitOps repository            |                          |
-| `gitops-prod`               | Files which should be updated by the GitHub Action for PROD, must be relative to the root of the GitOps repository             |                          |
-| `working-directory`         | The directory in which the GitOps action should be executed. The docker-file variable should be relative to working directory. | `.`                      |
+| Name                        | Description                                                                                                                    | Default                     |
+|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------|-----------------------------|
+| `docker-registry`           | Docker Registry                                                                                                                | `staffbase.jfrog.io`        |
+| `docker-image`              | Docker Image                                                                                                                   |                             |
+| `docker-username`           | Username for the Docker Registry                                                                                               |                             |
+| `docker-password`           | Password for the Docker Registry                                                                                               |                             |
+| `docker-file`               | Dockerfile                                                                                                                     | `./Dockerfile`              |
+| `docker-build-args`         | List of build-time variables                                                                                                   |                             |
+| `docker-build-secrets`      | List of secrets to expose to the build (e.g., key=string, GIT_AUTH_TOKEN=mytoken)                                              |                             |
+| `docker-build-secret-files` | List of secret files to expose to the build (e.g., key=filename, MY_SECRET=./secret.txt)                                       |                             |
+| `docker-build-target`       | Sets the target stage to build like: "runtime"                                                                                 |                             |
+| `docker-build-provenance`   | Generate [provenance](https://docs.docker.com/build/attestations/slsa-provenance/) attestation for the build                   | `mode=min,inline-only=true` |
+| `gitops-organization`       | GitHub Organization for GitOps                                                                                                 | `Staffbase`                 |
+| `gitops-repository`         | GitHub Repository for GitOps                                                                                                   | `mops`                      |
+| `gitops-user`               | GitHub User for GitOps                                                                                                         | `Staffbot`                  |
+| `gitops-email`              | GitHub Email for GitOps                                                                                                        | `staffbot@staffbase.com`    |
+| `gitops-token`              | GitHub Token for GitOps                                                                                                        |                             |
+| `gitops-dev`                | Files which should be updated by the GitHub Action for DEV, must be relative to the root of the GitOps repository              |                             |
+| `gitops-stage`              | Files which should be updated by the GitHub Action for STAGE, must be relative to the root of the GitOps repository            |                             |
+| `gitops-prod`               | Files which should be updated by the GitHub Action for PROD, must be relative to the root of the GitOps repository             |                             |
+| `working-directory`         | The directory in which the GitOps action should be executed. The docker-file variable should be relative to working directory. | `.`                         |
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -140,6 +140,7 @@ runs:
         platforms: linux/amd64
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        provenance: mode=min,inline-only=true
 
     - name: Checkout GitOps Repository
       if: inputs.gitops-token != ''

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
     required: false
   docker-build-provenance:
     description: "Generate provenance attestation for the build"
-    refquired: false
+    required: false
     default: 'mode=min,inline-only=true'
   gitops-organization:
     description: 'GitHub Organization for GitOps'

--- a/action.yml
+++ b/action.yml
@@ -140,7 +140,7 @@ runs:
         platforms: linux/amd64
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        provenance: mode=min,inline-only=true
+        provenance: false
 
     - name: Checkout GitOps Repository
       if: inputs.gitops-token != ''

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
   docker-build-target:
     description: "Sets the target stage to build"
     required: false
+  docker-build-provenance:
+    description: "Generate provenance attestation for the build"
+    refquired: false
+    default: 'mode=min,inline-only=true'
   gitops-organization:
     description: 'GitHub Organization for GitOps'
     required: true
@@ -140,7 +144,7 @@ runs:
         platforms: linux/amd64
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        provenance: false
+        provenance: ${{ inputs.docker-build-provenance }}
 
     - name: Checkout GitOps Repository
       if: inputs.gitops-token != ''


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [x] Documentation

### Description

We implemented the `provenance` attestations for `docker-build-push` action. We need to have this configurable for private registries. Some of them (e.g. Artifactory) are not compatible with this format. 

Background: With enabled `provenance` X-Ray from Artifactory is not working as expected.

See the change in the Release Notes: https://github.com/docker/build-push-action/releases/tag/v4.0.0

Feature: https://docs.docker.com/build/attestations/slsa-provenance/

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [x] Review the [Contributing Guideline](../blob/master/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
