### PR TITLE
DIA-3549 Retag release images instead of rebuilding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # 🚀 GitHub Action for GitOps
 
-This GitHub Action can be used for our GitOps workflow.
-The GitHub Action will build and push the Docker image for your service and deploys the new version at your Kubernetes clusters.
+This GitHub Action can be used for our GitOps workflow. The GitHub Action will build and push the Docker image for your service and deploys
+the new version at your Kubernetes clusters.
 
 ## Requirement
 
-When you want to use this GitHub Action your GitHub repository should have a `dev` and `master` / `main` branch and it should use tags for releases.
+When you want to use this GitHub Action your GitHub repository should have a `dev` and `master` / `main` branch and it should use tags for
+releases.
 
 - For the `dev` branch we will change the files specified under `gitops-dev`.
 - For the `master` / `main` branch we will change the files specified under `gitops-stage`.
 - For a new tag the files under `gitops-prod` will be used.
 
-This GitOps setup should be the default for all your repositories.
-However, if you have a special case, you can leave `gitops-dev`, `gitops-stage` and `gitops-prod` undefined, then those steps will be skipped.
+This GitOps setup should be the default for all your repositories. However, if you have a special case, you can
+leave `gitops-dev`, `gitops-stage` and `gitops-prod` undefined, then those steps will be skipped.
 
 ## Usages
 
@@ -21,7 +22,7 @@ However, if you have a special case, you can leave `gitops-dev`, `gitops-stage` 
 ```yaml
 name: CD
 
-on: [push]
+on: [ push ]
 
 jobs:
   ci-cd:
@@ -53,7 +54,7 @@ jobs:
 ```yaml
 name: CD
 
-on: [push]
+on: [ push ]
 
 jobs:
   ci-cd:
@@ -78,7 +79,7 @@ jobs:
 ```yaml
 name: CD
 
-on: [push]
+on: [ push ]
 
 jobs:
   ci-cd:
@@ -105,27 +106,29 @@ jobs:
 
 ## Inputs
 
-| Name                        | Description                                                                                                                    | Default                     |
-|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------|-----------------------------|
-| `docker-registry`           | Docker Registry                                                                                                                | `staffbase.jfrog.io`        |
-| `docker-image`              | Docker Image                                                                                                                   |                             |
-| `docker-username`           | Username for the Docker Registry                                                                                               |                             |
-| `docker-password`           | Password for the Docker Registry                                                                                               |                             |
-| `docker-file`               | Dockerfile                                                                                                                     | `./Dockerfile`              |
-| `docker-build-args`         | List of build-time variables                                                                                                   |                             |
-| `docker-build-secrets`      | List of secrets to expose to the build (e.g., key=string, GIT_AUTH_TOKEN=mytoken)                                              |                             |
-| `docker-build-secret-files` | List of secret files to expose to the build (e.g., key=filename, MY_SECRET=./secret.txt)                                       |                             |
-| `docker-build-target`       | Sets the target stage to build like: "runtime"                                                                                 |                             |
-| `docker-build-provenance`   | Generate [provenance](https://docs.docker.com/build/attestations/slsa-provenance/) attestation for the build                   | `false`                     |
-| `gitops-organization`       | GitHub Organization for GitOps                                                                                                 | `Staffbase`                 |
-| `gitops-repository`         | GitHub Repository for GitOps                                                                                                   | `mops`                      |
-| `gitops-user`               | GitHub User for GitOps                                                                                                         | `Staffbot`                  |
-| `gitops-email`              | GitHub Email for GitOps                                                                                                        | `staffbot@staffbase.com`    |
-| `gitops-token`              | GitHub Token for GitOps                                                                                                        |                             |
-| `gitops-dev`                | Files which should be updated by the GitHub Action for DEV, must be relative to the root of the GitOps repository              |                             |
-| `gitops-stage`              | Files which should be updated by the GitHub Action for STAGE, must be relative to the root of the GitOps repository            |                             |
-| `gitops-prod`               | Files which should be updated by the GitHub Action for PROD, must be relative to the root of the GitOps repository             |                             |
-| `working-directory`         | The directory in which the GitOps action should be executed. The docker-file variable should be relative to working directory. | `.`                         |
+| Name                        | Description                                                                                                                    | Default                                              |
+|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
+| `docker-registry`           | Docker Registry                                                                                                                | `staffbase.jfrog.io`                                 |
+| `docker-registry-api`       | Docker Registry API (used for retagging without pulling)                                                                       | `https://staffbase.jfrog.io/artifactory/api/docker/` |
+| `docker-image`              | Docker Image                                                                                                                   |                                                      |
+| `docker-username`           | Username for the Docker Registry                                                                                               |                                                      |
+| `docker-password`           | Password for the Docker Registry                                                                                               |                                                      |
+| `docker-file`               | Dockerfile                                                                                                                     | `./Dockerfile`                                       |
+| `docker-build-args`         | List of build-time variables                                                                                                   |                                                      |
+| `docker-build-secrets`      | List of secrets to expose to the build (e.g., key=string, GIT_AUTH_TOKEN=mytoken)                                              |                                                      |
+| `docker-build-secret-files` | List of secret files to expose to the build (e.g., key=filename, MY_SECRET=./secret.txt)                                       |                                                      |
+| `docker-build-target`       | Sets the target stage to build like: "runtime"                                                                                 |                                                      |
+| `docker-build-provenance`   | Generate [provenance](https://docs.docker.com/build/attestations/slsa-provenance/) attestation for the build                   | `false`                                              |
+| `docker-disable-retagging`  | Disables retagging of existing images and run a new build instead                                                              | `false`                                              |
+| `gitops-organization`       | GitHub Organization for GitOps                                                                                                 | `Staffbase`                                          |
+| `gitops-repository`         | GitHub Repository for GitOps                                                                                                   | `mops`                                               |
+| `gitops-user`               | GitHub User for GitOps                                                                                                         | `Staffbot`                                           |
+| `gitops-email`              | GitHub Email for GitOps                                                                                                        | `staffbot@staffbase.com`                             |
+| `gitops-token`              | GitHub Token for GitOps                                                                                                        |                                                      |
+| `gitops-dev`                | Files which should be updated by the GitHub Action for DEV, must be relative to the root of the GitOps repository              |                                                      |
+| `gitops-stage`              | Files which should be updated by the GitHub Action for STAGE, must be relative to the root of the GitOps repository            |                                                      |
+| `gitops-prod`               | Files which should be updated by the GitHub Action for PROD, must be relative to the root of the GitOps repository             |                                                      |
+| `working-directory`         | The directory in which the GitOps action should be executed. The docker-file variable should be relative to working directory. | `.`                                                  |
 
 ## Contributing
 
@@ -150,5 +153,4 @@ This project is licensed under the Apache-2.0 License - see the [LICENSE.md](LIC
 
 ## Releasing new versions
 
-Go to the release overview page and publish the draft release with a new version number.
-Make sure to update the floating version commit.
+Go to the release overview page and publish the draft release with a new version number. Make sure to update the floating version commit.

--- a/action.yml
+++ b/action.yml
@@ -123,7 +123,6 @@ runs:
         fi
 
         echo "build=$BUILD" >> $GITHUB_OUTPUT
-        echo "image_name=${{ inputs.docker-registry }}/${{ inputs.docker-image }}" >> $GITHUB_OUTPUT
         echo "latest=$LATEST" >> $GITHUB_OUTPUT
         echo "push=$PUSH" >> $GITHUB_OUTPUT
         echo "tag=$TAG" >> $GITHUB_OUTPUT
@@ -160,7 +159,7 @@ runs:
         cache-to: type=gha,mode=max
         provenance: ${{ inputs.docker-build-provenance }}
 
-    - name: Retag existing image
+    - name: Retag Existing Image
       id: docker_retag
       if: steps.preparation.outputs.build == 'false'
       shell: bash
@@ -174,24 +173,24 @@ runs:
 
         echo "CHECK_EXISTING_TAGS: ${CHECK_EXISTING_TAGS}"
         echo "RELEASE_TAG: ${RELEASE_TAG:1}"
-        echo "Check if an image already exists for ${{steps.preparation.outputs.image_name }}:main|master-${GITHUB_SHA::8} 🐋 ⬇"
+        echo "Check if an image already exists for ${{ inputs.docker-image }}:main|master-${GITHUB_SHA::8} 🐋 ⬇"
 
         MANIFEST=""
         for tag in $CHECK_EXISTING_TAGS; do
           MANIFEST=$(curl -H "Accept: ${CONTENT_TYPE}" -u "${{ inputs.docker-username }}:${{ inputs.docker-password }}" "${{ inputs.docker-registry-api }}${REPO}/v2/{$IMAGE}/manifests/${tag}")
 
           if [[ $MANIFEST == *"errors"* ]]; then
-            echo "No image found for ${{ steps.preparation.outputs.image_name }}:${tag} 🚫"
+            echo "No image found for ${{ inputs.docker-image }}:${tag} 🚫"
             continue
           else
-            echo "Image found for ${{ steps.preparation.outputs.image_name }}:${tag} 🐋 ⬇"
+            echo "Image found for ${{ inputs.docker-image }}:${tag} 🐋 ⬇"
             break
           fi
           # Exit here if no existing manifest was found
           exit 1
         done
 
-        echo "Retagging image with release version and :latest tags for ${{ steps.preparation.outputs.image_name }} 🏷"
+        echo "Retagging image with release version and :latest tags for ${{ inputs.docker-image }} 🏷"
         curl --fail-with-body -X PUT -H "Content-Type: ${CONTENT_TYPE}" -u "${{ inputs.docker-username }}:${{ inputs.docker-password }}" -d "${MANIFEST}" "${{ inputs.docker-registry-api }}${REPO}/v2/{$IMAGE}/manifests/${{ steps.preparation.outputs.tag }}"
         curl --fail-with-body -X PUT -H "Content-Type: ${CONTENT_TYPE}" -u "${{ inputs.docker-username }}:${{ inputs.docker-password }}" -d "${MANIFEST}" "${{ inputs.docker-registry-api }}${REPO}/v2/{$IMAGE}/manifests/${{ steps.preparation.outputs.latest }}"
 

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: 'Docker Registry'
     required: true
     default: 'staffbase.jfrog.io'
+  docker-registry-api:
+    description: 'Docker Registry API'
+    required: false
+    default: 'https://staffbase.jfrog.io/artifactory/api/docker/'
   docker-image:
     description: 'Docker Image'
     required: true
@@ -34,6 +38,10 @@ inputs:
     required: false
   docker-build-provenance:
     description: "Generate provenance attestation for the build"
+    required: false
+    default: 'false'
+  docker-disable-retagging:
+    description: 'Disable retagging of existing images'
     required: false
     default: 'false'
   gitops-organization:
@@ -81,6 +89,7 @@ runs:
       id: preparation
       shell: bash
       run: |
+        BUILD="true"
         if [[ $GITHUB_REF == refs/heads/master ]]; then
           TAG="master-${GITHUB_SHA::8}"
           LATEST="master"
@@ -97,10 +106,12 @@ runs:
           TAG="${GITHUB_REF:11}"
           LATEST="latest"
           PUSH="true"
+          BUILD="${{ inputs.docker-disable-retagging }}"
         elif [[ $GITHUB_REF == refs/tags/* ]]; then
           TAG="${GITHUB_REF:10}"
           LATEST="latest"
           PUSH="true"
+          BUILD="${{ inputs.docker-disable-retagging }}"
         else
           TAG="${GITHUB_SHA::8}"
           PUSH="false"
@@ -111,10 +122,12 @@ runs:
           TAG_LIST+=",${{ inputs.docker-registry }}/${{ inputs.docker-image }}:${LATEST}"
         fi
 
-        echo "tag_list=$TAG_LIST" >> $GITHUB_OUTPUT
-        echo "tag=$TAG" >> $GITHUB_OUTPUT
+        echo "build=$BUILD" >> $GITHUB_OUTPUT
+        echo "image_name=${{ inputs.docker-registry }}/${{ inputs.docker-image }}" >> $GITHUB_OUTPUT
         echo "latest=$LATEST" >> $GITHUB_OUTPUT
         echo "push=$PUSH" >> $GITHUB_OUTPUT
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
+        echo "tag_list=$TAG_LIST" >> $GITHUB_OUTPUT
 
     - name: Set up Docker Buildx
       if: inputs.docker-username != '' && inputs.docker-password != ''
@@ -128,9 +141,10 @@ runs:
         username: ${{ inputs.docker-username }}
         password: ${{ inputs.docker-password }}
 
+
     - name: Build
       id: docker_build
-      if: inputs.docker-username != '' && inputs.docker-password != ''
+      if: steps.preparation.outputs.build == 'true' && inputs.docker-username != '' && inputs.docker-password != ''
       uses: docker/build-push-action@v5
       with:
         context: ${{ inputs.working-directory }}
@@ -145,6 +159,41 @@ runs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
         provenance: ${{ inputs.docker-build-provenance }}
+
+    - name: Retag existing image
+      id: docker_retag
+      if: steps.preparation.outputs.build == 'false'
+      shell: bash
+      run: |
+        CHECK_EXISTING_TAGS="master-${GITHUB_SHA::8} main-${GITHUB_SHA::8}"
+        CONTENT_TYPE="application/vnd.docker.distribution.manifest.v2+json"
+
+        # split docker-image on / into repository and image
+        REPO=$(echo ${{ inputs.docker-image}} | cut -d'/' -f1)
+        IMAGE=$(echo ${{ inputs.docker-image}} | cut -d'/' -f2)
+
+        echo "CHECK_EXISTING_TAGS: ${CHECK_EXISTING_TAGS}"
+        echo "RELEASE_TAG: ${RELEASE_TAG:1}"
+        echo "Check if an image already exists for ${{steps.preparation.outputs.image_name }}:main|master-${GITHUB_SHA::8} 🐋 ⬇"
+
+        MANIFEST=""
+        for tag in $CHECK_EXISTING_TAGS; do
+          MANIFEST=$(curl -H "Accept: ${CONTENT_TYPE}" -u "${{ inputs.docker-username }}:${{ inputs.docker-password }}" "${{ inputs.docker-registry-api }}${REPO}/v2/{$IMAGE}/manifests/${tag}")
+
+          if [[ $MANIFEST == *"errors"* ]]; then
+            echo "No image found for ${{ steps.preparation.outputs.image_name }}:${tag} 🚫"
+            continue
+          else
+            echo "Image found for ${{ steps.preparation.outputs.image_name }}:${tag} 🐋 ⬇"
+            break
+          fi
+          # Exit here if no existing manifest was found
+          exit 1
+        done
+
+        echo "Retagging image with release version and :latest tags for ${{ steps.preparation.outputs.image_name }} 🏷"
+        curl --fail-with-body -X PUT -H "Content-Type: ${CONTENT_TYPE}" -u "${{ inputs.docker-username }}:${{ inputs.docker-password }}" -d "${MANIFEST}" "${{ inputs.docker-registry-api }}${REPO}/v2/{$IMAGE}/manifests/${{ steps.preparation.outputs.tag }}"
+        curl --fail-with-body -X PUT -H "Content-Type: ${CONTENT_TYPE}" -u "${{ inputs.docker-username }}:${{ inputs.docker-password }}" -d "${MANIFEST}" "${{ inputs.docker-registry-api }}${REPO}/v2/{$IMAGE}/manifests/${{ steps.preparation.outputs.latest }}"
 
     - name: Checkout GitOps Repository
       if: inputs.gitops-token != ''


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

Fixes #37

Retags an image if it already exists in the registry under a different name. This will make sure that we only run images in production that are tested on other stages and we now that they are actually the same image.

This is done without the need to pull the image first but through reuploading the manifest file.

See: https://github.com/Staffbase/apperator/actions/runs/9223474563/job/25376806824

It also saves some bandwith and Github Action minutes. :)

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Review the [Contributing Guideline](../blob/master/CONTRIBUTING.md) and sign CLA
- [x] Reference relevant issue(s) and close them after merging
