### PR TITLE
support defining custom tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ jobs:
 | `docker-registry`           | Docker Registry                                                                                                                | `staffbase.jfrog.io`                                 |
 | `docker-registry-api`       | Docker Registry API (used for retagging without pulling)                                                                       | `https://staffbase.jfrog.io/artifactory/api/docker/` |
 | `docker-image`              | Docker Image                                                                                                                   |                                                      |
+| `docker-custom-tag`         | Docker Custom Tag to be set on the image                                                                                       |                                                      |
 | `docker-username`           | Username for the Docker Registry                                                                                               |                                                      |
 | `docker-password`           | Password for the Docker Registry                                                                                               |                                                      |
 | `docker-file`               | Dockerfile                                                                                                                     | `./Dockerfile`                                       |

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   docker-image:
     description: 'Docker Image'
     required: true
+  docker-custom-tag:
+    description: 'Docker Custom Tag'
+    required: false
   docker-username:
     description: 'Username for the Docker Registry'
     required: false
@@ -90,7 +93,12 @@ runs:
       shell: bash
       run: |
         BUILD="true"
-        if [[ $GITHUB_REF == refs/heads/master ]]; then
+        if [[ -n "${{ inputs.docker-custom-tag }}" ]]; then
+          TAG="${{ inputs.docker-custom-tag }}"
+          LATEST="latest"
+          PUSH="true"
+          BUILD="${{ inputs.docker-disable-retagging }}"
+        elif [[ $GITHUB_REF == refs/heads/master ]]; then
           TAG="master-${GITHUB_SHA::8}"
           LATEST="master"
           PUSH="true"


### PR DESCRIPTION
Feel free to ping me on slack for a longer explanation of why we need this in the data platform.

### Type of Change

<!-- Select the type of your PR -->

- [ ] Bugfix
- [X] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

This PR adds support for an input `docker-custom-tag`, which allows the user to override the tag set by the workflow. This is useful in i.e. a monorepo case where users might want to release only parts of the project by tagging it with `prefix/version`.

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [x] Review the [Contributing Guideline](../blob/master/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
