### PR TITLE
retry image retagging for 300 seconds

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -195,9 +195,12 @@ runs:
         done
 
         echo "Retagging image with release version and :latest tags for ${{ inputs.docker-image }} 🏷"
-        curl --fail-with-body -X PUT -H "Content-Type: ${CONTENT_TYPE}" -u '${{ inputs.docker-username }}:${{ inputs.docker-password }}' -d "${MANIFEST}" "${{ inputs.docker-registry-api }}${{ inputs.docker-image}}/manifests/${{ steps.preparation.outputs.tag }}"
-        curl --fail-with-body -X PUT -H "Content-Type: ${CONTENT_TYPE}" -u '${{ inputs.docker-username }}:${{ inputs.docker-password }}' -d "${MANIFEST}" "${{ inputs.docker-registry-api }}${{ inputs.docker-image}}/manifests/${{ steps.preparation.outputs.latest }}"
-
+        end=$((SECONDS+300))
+        while [ $SECONDS -lt $end ]; do
+          curl --fail-with-body -X PUT -H "Content-Type: ${CONTENT_TYPE}" -u '${{ inputs.docker-username }}:${{ inputs.docker-password }}' -d "${MANIFEST}" "${{ inputs.docker-registry-api }}${{ inputs.docker-image}}/manifests/${{ steps.preparation.outputs.tag }}" &&
+          curl --fail-with-body -X PUT -H "Content-Type: ${CONTENT_TYPE}" -u '${{ inputs.docker-username }}:${{ inputs.docker-password }}' -d "${MANIFEST}" "${{ inputs.docker-registry-api }}${{ inputs.docker-image}}/manifests/${{ steps.preparation.outputs.latest }}" && break
+          sleep 10
+        done
     - name: Checkout GitOps Repository
       if: inputs.gitops-token != ''
       uses: actions/checkout@v4


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

Retry the image retagging for releases for atleast 5 min. This should reduce cd failures when you merge to main and immediately trigger a release like here: https://github.com/Staffbase/customer-control/actions/runs/10773567525/job/29873909087#step:4:322

### Checklist

I could imagine some rare edge cases when you trigger two releases within those 5 minutes of retry where the false image gets the latest tag. I dont know if this is relevant.

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Review the [Contributing Guideline](../blob/master/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
