### PR TITLE
Emit upwind.io build event

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,6 +75,15 @@ inputs:
   gitops-prod:
     description: 'Files which should be updated by the GitHub Action for PROD'
     required: false
+  upwind-client-id:
+    description: 'Upwind Client ID'
+    required: false
+  upwind-organization-id:
+    description: 'Upwind Organization ID'
+    required: false
+  upwind-client-secret:
+    description: 'Upwind Client Secret'
+    required: false
   working-directory:
     description: 'The path relative to the repo root dir in which the GitOps action should be executed.'
     required: false
@@ -299,6 +308,19 @@ runs:
             yq -i .${array[1]}=\"${{ inputs.docker-registry }}/${{ inputs.docker-image }}:${{ steps.preparation.outputs.tag }}\" ${array[0]}
           done <<< "${{ inputs.gitops-dev }}"
         fi
+
+    - name: Emit Image Build Event to Upwind.io
+      env:
+        UPWIND_CLIENT_SECRET: ${{ inputs.upwind-client-secret }}
+      if: "${{ inputs.upwind-client-id != '' && env.UPWIND_CLIENT_SECRET != '' && inputs.upwind-organization-id != '' }}"
+      uses: upwindsecurity/create-image-build-event-action@v2
+      continue-on-error: true
+      with:
+        image: ${{ inputs.docker-image }}
+        image_sha: ${{ steps.docker_build.outputs.digest || steps.docker_retag.outputs.digest }}
+        upwind_client_id: ${{ inputs.upwind-client-id }}
+        upwind_client_secret: ${{ env.UPWIND_CLIENT_SECRET }}
+        upwind_organization_id: ${{ inputs.upwind-organization-id }}
 
 branding:
   icon: 'git-merge'


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

- [x] [No changes in behavior without supplying new arguments](https://github.com/Staffbase/tech-radar/actions/runs/11403816798/job/31731687833?pr=86#step:6:582)
- [x] [Emit event in `dev` when adding new vars](https://github.com/Staffbase/tech-radar/actions/runs/11404088119/job/31732540789#step:6:638)
- [x] [Emit event when merging to `main`](https://github.com/Staffbase/tech-radar/actions/runs/11404171544/job/31732793496#step:6:652)
- [x] [Emit event when retagging](https://github.com/Staffbase/tech-radar/actions/runs/11404575517/job/31734051152#step:7:555)

When we release a new version and people don't adjust the vars, nothing will change.
But if they add the vars, an event will be emitted and [Upwind can visualize that](https://console.upwind.io/inventory?mainPageTab=Images&selectedAttackItemId=15&selectedTab1=Overview&sidePanel=image-details&sidePanelItemId=registry.staffbase.com%252Fsb-images%252Fcasper%253A0.0.26%257C%257C%257Cimage%257C%257C%257C452097f3-3fe6-4984-ab17-844eaa1a08a6%257C%257C%257C%257C%257C%257C&filters=imageFullName=sb-images/casper)

![image](https://github.com/user-attachments/assets/a3e87cb8-d15f-49ca-820f-8044ad8280bc)

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [x] Review the [Contributing Guideline](../blob/master/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
