### PR TITLE
CI-1135: replace secrets.HARBOR_USERNAME with vars.HARBOR_USERNAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jobs:
       - name: GitOps (build, push and deploy a new Docker image)
         uses: Staffbase/gitops-github-action@v6.0
         with:
-          docker-username: ${{ secrets.HARBOR_USERNAME }}
+          docker-username: ${{ vars.HARBOR_USERNAME }}
           docker-password: ${{ secrets.HARBOR_PASSWORD }}
           docker-image: private/diablo-redbook
           gitops-token: ${{ secrets.GITOPS_TOKEN }}
@@ -71,7 +71,7 @@ jobs:
       - name: GitOps (build and push a new Docker image)
         uses: Staffbase/gitops-github-action@v6.0
         with:
-          docker-username: ${{ secrets.HARBOR_USERNAME }}
+          docker-username: ${{ vars.HARBOR_USERNAME }}
           docker-password: ${{ secrets.HARBOR_PASSWORD }}
           docker-image: private/diablo-redbook
 ```


### PR DESCRIPTION
## Summary

- Replace all usages of `secrets.HARBOR_USERNAME` with `vars.HARBOR_USERNAME`
- The Harbor username was never a secret and is now an [organization variable](https://github.com/Staffbase/infrastructure/pull/13579) instead

Refs: [CI-1135](https://mitarbeiterapp.atlassian.net/browse/CI-1135)

[CI-1135]: https://mitarbeiterapp.atlassian.net/browse/CI-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ