### PR TITLE
chore: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request'
-        uses: cla-assistant/github-action@v2.6.1
+        uses: cla-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.OSS_CONTRIBUTOR_LICENSE_AGREEMENT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    uses: Staffbase/gha-workflows/.github/workflows/template_release_drafter.yml@v12.0.1
+    uses: Staffbase/gha-workflows/.github/workflows/template_release_drafter.yml@963c984dde02b0a8711f0d098aa9f8a7f2e50bca # v12.0.1
     secrets:
       app_id: ${{ vars.STAFFBASE_ACTIONS_APP_ID }}
       private_key: ${{ secrets.STAFFBASE_ACTIONS_PRIVATE_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -185,11 +185,11 @@ runs:
 
     - name: Set up Docker Buildx
       if: inputs.docker-username != '' && inputs.docker-password != ''
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
     - name: Login to Registry
       if: inputs.docker-username != '' && inputs.docker-password != ''
-      uses: docker/login-action@v4
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
         registry: ${{ inputs.docker-registry }}
         username: ${{ inputs.docker-username }}
@@ -199,7 +199,7 @@ runs:
     - name: Build
       id: docker_build
       if: steps.preparation.outputs.build == 'true' && inputs.docker-username != '' && inputs.docker-password != ''
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
         context: ${{ inputs.working-directory }}
         push: ${{ inputs.docker-build-outputs == '' && steps.preparation.outputs.push || 'false' }}
@@ -276,7 +276,7 @@ runs:
 
     - name: Checkout GitOps Repository
       if: inputs.gitops-token != ''
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.gitops-organization }}/${{ inputs.gitops-repository }}
         token: ${{ inputs.gitops-token }}
@@ -361,7 +361,7 @@ runs:
       env:
         UPWIND_CLIENT_SECRET: ${{ inputs.upwind-client-secret }}
       if: "${{ inputs.upwind-client-id != '' && env.UPWIND_CLIENT_SECRET != '' && inputs.upwind-organization-id != '' }}"
-      uses: upwindsecurity/create-image-build-event-action@v3
+      uses: upwindsecurity/create-image-build-event-action@3099fc1e1e002c6c2d7b7c635699944a708d260d # v3
       continue-on-error: true
       with:
         image: ${{ inputs.docker-image }}


### PR DESCRIPTION
### Type of Change

- [ ] Bugfix
- [ ] Enhancement / new feature
- [x] Refactoring
- [ ] Documentation

### Description

Pin all GitHub Actions dependencies to their full commit SHAs instead of mutable version tags to improve supply chain security. Each SHA is annotated with a version comment (e.g. `# v4.0.0`) for readability.

**Changes across 3 files (7 actions pinned):**

| Action | Version |
|--------|---------|
| `docker/setup-buildx-action` | v4.0.0 |
| `docker/login-action` | v4.1.0 |
| `docker/build-push-action` | v7.0.0 |
| `actions/checkout` | v6.0.2 |
| `upwindsecurity/create-image-build-event-action` | v3 |
| `cla-assistant/github-action` | v2.6.1 |
| `Staffbase/gha-workflows` | v12.0.1 |

All versions are already at their latest stable release.

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging

---
<sub>The changes and the PR were generated by OpenCode.</sub>