### PR TITLE
fix: deactivate stale in-progress deployments before creating new ones

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -334,10 +334,50 @@ runs:
           echo "${env}-${cluster}"
         }
 
+        deactivate_stale_deployments () {
+          local environment="$1"
+
+          local deployments_response
+          deployments_response=$(curl -s \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN_INPUT}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/deployments?environment=${environment}&per_page=30")
+
+          local deployment_ids
+          deployment_ids=$(echo "$deployments_response" | jq -r '.[].id // empty')
+
+          for dep_id in $deployment_ids; do
+            local status_response
+            status_response=$(curl -s \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN_INPUT}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/deployments/${dep_id}/statuses?per_page=1")
+
+            local latest_state
+            latest_state=$(echo "$status_response" | jq -r '.[0].state // empty')
+
+            if [[ "$latest_state" == "in_progress" || "$latest_state" == "queued" || "$latest_state" == "pending" ]]; then
+              echo "Marking stale deployment ${dep_id} (${latest_state}) as inactive" >&2
+              curl -s \
+                -X POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${GITHUB_TOKEN_INPUT}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "https://api.github.com/repos/${GITHUB_REPOSITORY}/deployments/${dep_id}/statuses" \
+                -d '{"state": "inactive", "description": "Superseded by newer deployment"}' > /dev/null
+            fi
+          done
+        }
+
         create_deployment () {
           local environment="$1"
           local image="$2"
           local tag="$3"
+
+          # Deactivate any previous in-progress deployments for this environment
+          deactivate_stale_deployments "${environment}"
 
           RESPONSE=$(curl -s -w "\n%{http_code}" \
             -X POST \


### PR DESCRIPTION
### Type of Change

- [x] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

When the Kustomization is updated in quick succession (e.g. two pushes to `main` within seconds), GitHub Deployments can become orphaned — stuck in `in_progress` forever. This happens because the `deploy.staffbase.com/deployment-id` annotation in the GitOps repo gets overwritten by the subsequent run, and the `flux-deployment-reporter` only sees the latest ID.

This adds a `deactivate_stale_deployments()` function that runs before each new deployment creation. It queries existing deployments for the target environment via the GitHub API and marks any with status `in_progress`, `queued`, or `pending` as `inactive` ("Superseded by newer deployment").

The cleanup is best-effort (failures don't block new deployments) and idempotent (concurrent runs deactivating the same deployment is harmless).

Note: GitHub's built-in `auto_inactive` parameter only affects deployments that previously reached `success` state and does not help with orphaned `in_progress` deployments.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Review the [Contributing Guideline](../blob/master/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging

---
<sub>The changes and the PR were generated by Claude.</sub>