### PR TITLE
Update CODEOWNERS to change team ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @Staffbase/diablo @Staffbase/workflow-enthusiasts
+*       @Staffbase/product-core-infra @Staffbase/workflow-enthusiasts

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ jobs:
         with:
           docker-username: ${{ vars.HARBOR_USERNAME }}
           docker-password: ${{ secrets.HARBOR_PASSWORD }}
-          docker-image: private/diablo-redbook
+          docker-image: private/my-service
           gitops-token: ${{ secrets.GITOPS_TOKEN }}
           gitops-dev: |-
-            clusters/customization/dev/mothership/diablo-redbook/diablo-redbook-helm.yaml spec.template.spec.containers.redbook.image
+            clusters/customization/dev/mothership/my-service/my-service-helm.yaml spec.template.spec.containers.redbook.image
           gitops-stage: |-
-            clusters/customization/stage/mothership/diablo-redbook/diablo-redbook-helm.yaml spec.template.spec.containers.redbook.image
+            clusters/customization/stage/mothership/my-service/my-service-helm.yaml spec.template.spec.containers.redbook.image
           gitops-prod: |-
-            clusters/customization/prod/mothership/diablo-redbook/diablo-redbook-helm.yaml spec.template.spec.containers.redbook.image
+            clusters/customization/prod/mothership/my-service/my-service-helm.yaml spec.template.spec.containers.redbook.image
 ```
 
 ### Build and Push Docker Image
@@ -73,7 +73,7 @@ jobs:
         with:
           docker-username: ${{ vars.HARBOR_USERNAME }}
           docker-password: ${{ secrets.HARBOR_PASSWORD }}
-          docker-image: private/diablo-redbook
+          docker-image: private/my-service
 ```
 
 ### Deploy Docker Image
@@ -96,14 +96,14 @@ jobs:
       - name: GitOps (deploy a new Docker image)
         uses: Staffbase/gitops-github-action@v7.1
         with:
-          docker-image: private/diablo-redbook
+          docker-image: private/my-service
           gitops-token: ${{ secrets.GITOPS_TOKEN }}
           gitops-dev: |-
-            clusters/customization/dev/mothership/diablo-redbook/diablo-redbook-helm.yaml spec.template.spec.containers.redbook.image
+            clusters/customization/dev/mothership/my-service/my-service-helm.yaml spec.template.spec.containers.redbook.image
           gitops-stage: |-
-            clusters/customization/stage/mothership/diablo-redbook/diablo-redbook-helm.yaml spec.template.spec.containers.redbook.image
+            clusters/customization/stage/mothership/my-service/my-service-helm.yaml spec.template.spec.containers.redbook.image
           gitops-prod: |-
-            clusters/customization/prod/mothership/diablo-redbook/diablo-redbook-helm.yaml spec.template.spec.containers.redbook.image
+            clusters/customization/prod/mothership/my-service/my-service-helm.yaml spec.template.spec.containers.redbook.image
 ```
 
 ### Deployment tracking annotations


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [ ] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

This pull request updates ownership and deployment configuration to reflect a service rename from `diablo-redbook` to `my-service`. The changes ensure that all references, including Docker image names, deployment paths, and code ownership, are aligned with the new service name.

Service rename and deployment updates:

* Updated all references in `README.md` from `diablo-redbook` to `my-service`, including Docker image names and GitOps deployment paths for dev, stage, and prod environments. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R51) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-R76) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L99-R106)

Ownership update:

* Changed the default code owners in `.github/CODEOWNERS` from `@Staffbase/diablo` to `@Staffbase/product-core-infra` to reflect the new responsible team.

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [x] Review the [Contributing Guideline](../blob/master/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
