### PR TITLE
fix: support staffbase-application Helm chart image field shape

### DIFF
--- a/scripts/lib/gitops-functions.sh
+++ b/scripts/lib/gitops-functions.sh
@@ -36,13 +36,16 @@ update_file() {
   echo "Check if path ${file} ${field} exists and get old current version"
   yq -e ."${field}" "${file}"
   echo "Run update ${file} ${field} ${image}"
-  local field_type
-  field_type=$(yq "(.${field} | type)" "${file}" 2>/dev/null || echo "!!null")
-  if [[ "${field_type}" == "!!map" ]]; then
-    echo "Field ${field} is a mapping — writing tag only to ${field}.tag"
-    yq -i ".${field}.tag=\"${INPUT_TAG}\"" "${file}"
+  if [[ "${field}" == *.tag ]]; then
+    yq -i ".${field}=\"${INPUT_TAG}\"" "${file}"
   else
-    yq -i ."${field}"=\""${image}"\" "${file}"
+    local field_type
+    field_type=$(yq "(.${field} | type)" "${file}" 2>/dev/null || echo "!!null")
+    if [[ "${field_type}" == "!!map" ]] && yq -e ".${field}.tag" "${file}" > /dev/null 2>&1; then
+      yq -i ".${field}.tag=\"${INPUT_TAG}\"" "${file}"
+    else
+      yq -i ."${field}"=\""${image}"\" "${file}"
+    fi
   fi
 
   echo "Writing deployment annotations to ${file}"

--- a/scripts/lib/gitops-functions.sh
+++ b/scripts/lib/gitops-functions.sh
@@ -36,7 +36,14 @@ update_file() {
   echo "Check if path ${file} ${field} exists and get old current version"
   yq -e ."${field}" "${file}"
   echo "Run update ${file} ${field} ${image}"
-  yq -i ."${field}"=\""${image}"\" "${file}"
+  local field_type
+  field_type=$(yq "(.${field} | type)" "${file}" 2>/dev/null || echo "!!null")
+  if [[ "${field_type}" == "!!map" ]]; then
+    echo "Field ${field} is a mapping — writing tag only to ${field}.tag"
+    yq -i ".${field}.tag=\"${INPUT_TAG}\"" "${file}"
+  else
+    yq -i ."${field}"=\""${image}"\" "${file}"
+  fi
 
   echo "Writing deployment annotations to ${file}"
   yq -i '.metadata.annotations["deploy.staffbase.com/repositoryFullName"] = "'"${GITHUB_REPOSITORY}"'"' "${file}"

--- a/tests/fixtures/helmrelease.yaml
+++ b/tests/fixtures/helmrelease.yaml
@@ -1,0 +1,13 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: my-service
+  namespace: my-service
+  annotations: {}
+spec:
+  values:
+    workload:
+      container:
+        image:
+          repository: registry.staffbase.com/sb-images/my-service
+          tag: placeholder

--- a/tests/lib-gitops-functions.bats
+++ b/tests/lib-gitops-functions.bats
@@ -51,6 +51,31 @@ teardown() {
 
 # --- update_file ---
 
+@test "update_file writes tag only when field value is a mapping" {
+  cat > "${TEST_TEMP_DIR}/mocks/yq" << 'YQ_MOCK'
+#!/usr/bin/env bash
+echo "yq $*" >> "${MOCK_CALLS_DIR}/yq_calls.log"
+if [[ "$*" == *"| type"* ]]; then echo "!!map"; fi
+exit 0
+YQ_MOCK
+  chmod +x "${TEST_TEMP_DIR}/mocks/yq"
+  update_file "helmrelease.yaml" "spec.values.workload.container.image" "$IMAGE"
+  grep -q ".spec.values.workload.container.image.tag=\"${INPUT_TAG}\"" "${TEST_TEMP_DIR}/yq_calls.log"
+  ! grep -q "${IMAGE}" "${TEST_TEMP_DIR}/yq_calls.log"
+}
+
+@test "update_file writes full URI when field value is a scalar" {
+  cat > "${TEST_TEMP_DIR}/mocks/yq" << 'YQ_MOCK'
+#!/usr/bin/env bash
+echo "yq $*" >> "${MOCK_CALLS_DIR}/yq_calls.log"
+if [[ "$*" == *"| type"* ]]; then echo "!!str"; fi
+exit 0
+YQ_MOCK
+  chmod +x "${TEST_TEMP_DIR}/mocks/yq"
+  update_file "deployment.yaml" "spec.template.spec.containers.app.image" "$IMAGE"
+  grep -q "${IMAGE}" "${TEST_TEMP_DIR}/yq_calls.log"
+}
+
 @test "update_file calls yq to check and update field" {
   update_file "deployment.yaml" "spec.image" "$IMAGE"
   assert [ -f "${TEST_TEMP_DIR}/yq_calls.log" ]

--- a/tests/lib-gitops-functions.bats
+++ b/tests/lib-gitops-functions.bats
@@ -51,7 +51,20 @@ teardown() {
 
 # --- update_file ---
 
-@test "update_file writes tag only when field value is a mapping" {
+@test "update_file writes full URI when field value is a scalar" {
+  cat > "${TEST_TEMP_DIR}/mocks/yq" << 'YQ_MOCK'
+#!/usr/bin/env bash
+echo "yq $*" >> "${MOCK_CALLS_DIR}/yq_calls.log"
+if [[ "$*" == *"| type"* ]]; then echo "!!str"; fi
+exit 0
+YQ_MOCK
+  chmod +x "${TEST_TEMP_DIR}/mocks/yq"
+  update_file "deployment.yaml" "spec.template.spec.containers.app.image" "$IMAGE"
+  grep -q "${IMAGE}" "${TEST_TEMP_DIR}/yq_calls.log"
+  ! grep -q ".tag=\"${INPUT_TAG}\"" "${TEST_TEMP_DIR}/yq_calls.log"
+}
+
+@test "update_file writes tag to .tag subfield when field is a map with tag property" {
   cat > "${TEST_TEMP_DIR}/mocks/yq" << 'YQ_MOCK'
 #!/usr/bin/env bash
 echo "yq $*" >> "${MOCK_CALLS_DIR}/yq_calls.log"
@@ -64,16 +77,10 @@ YQ_MOCK
   ! grep -q "${IMAGE}" "${TEST_TEMP_DIR}/yq_calls.log"
 }
 
-@test "update_file writes full URI when field value is a scalar" {
-  cat > "${TEST_TEMP_DIR}/mocks/yq" << 'YQ_MOCK'
-#!/usr/bin/env bash
-echo "yq $*" >> "${MOCK_CALLS_DIR}/yq_calls.log"
-if [[ "$*" == *"| type"* ]]; then echo "!!str"; fi
-exit 0
-YQ_MOCK
-  chmod +x "${TEST_TEMP_DIR}/mocks/yq"
-  update_file "deployment.yaml" "spec.template.spec.containers.app.image" "$IMAGE"
-  grep -q "${IMAGE}" "${TEST_TEMP_DIR}/yq_calls.log"
+@test "update_file writes tag only when field path ends with .tag" {
+  update_file "helmrelease.yaml" "spec.values.workload.container.image.tag" "$IMAGE"
+  grep -q ".spec.values.workload.container.image.tag=\"${INPUT_TAG}\"" "${TEST_TEMP_DIR}/yq_calls.log"
+  ! grep -q "${IMAGE}" "${TEST_TEMP_DIR}/yq_calls.log"
 }
 
 @test "update_file calls yq to check and update field" {


### PR DESCRIPTION
## Problem

Some Helm chart splits the image into a mapping:

```yaml
image:
  repository: foo.bar/lol/app
  tag: dev-abc123
```

When the action writes the full URI as a scalar to `spec.values.workload.container.image`, the kustomize patch replaces the mapping with a string. The chart template renders `{{ .image.repository }}:{{ .image.tag }}` as `:` — both fields resolve to empty.

## Fix

Three-case dispatch in `update_file()`:

**Case 1 — legacy (Apperator):** field resolves to a scalar → write full image URI unchanged. No behaviour change for existing callers.

**Case 2 — auto-detect (Helm):** field resolves to a `!!map` with a `.tag` property → write only `INPUT_TAG` to `.field.tag`. Caller specifies `spec.values.workload.container.image`, action handles the rest.

**Case 3 — explicit:** field path ends in `.tag` → write only `INPUT_TAG` directly to that field. For callers who prefer to be explicit.

## Backwards compatibility

All existing Apperator-style callers have scalar image fields and continue to receive the full URI unchanged (case 1). No `cicd.yml` changes required for existing services.