### PR TITLE
Fixing the string replacement in the helm chart to update  the tag instead of the image

### DIFF
--- a/scripts/lib/gitops-functions.sh
+++ b/scripts/lib/gitops-functions.sh
@@ -41,7 +41,7 @@ update_file() {
   else
     local field_type
     field_type=$(yq "(.${field} | type)" "${file}" 2>/dev/null || echo "!!null")
-    if [[ "${field_type}" == "!!map" ]] && yq -e ".${field}.tag" "${file}" > /dev/null 2>&1; then
+    if [[ "${field_type}" == "!!map" ]]; then
       yq -i ".${field}.tag=\"${INPUT_TAG}\"" "${file}"
     else
       yq -i ."${field}"=\""${image}"\" "${file}"

--- a/scripts/lib/gitops-functions.sh
+++ b/scripts/lib/gitops-functions.sh
@@ -41,7 +41,7 @@ update_file() {
   else
     local field_type
     field_type=$(yq "(.${field} | type)" "${file}" 2>/dev/null || echo "!!null")
-    if [[ "${field_type}" == "!!map" ]]; then
+    if [[ "${field_type}" == "!!map" ]] && yq -e ".${field} | (has(\"tag\") or has(\"repository\"))" "${file}" > /dev/null 2>&1; then
       yq -i ".${field}.tag=\"${INPUT_TAG}\"" "${file}"
     else
       yq -i ."${field}"=\""${image}"\" "${file}"

--- a/tests/lib-gitops-functions.bats
+++ b/tests/lib-gitops-functions.bats
@@ -64,7 +64,7 @@ YQ_MOCK
   ! grep -q ".tag=\"${INPUT_TAG}\"" "${TEST_TEMP_DIR}/yq_calls.log"
 }
 
-@test "update_file writes tag to .tag subfield when field is a map with tag property" {
+@test "update_file writes tag to .tag subfield when field is a map" {
   cat > "${TEST_TEMP_DIR}/mocks/yq" << 'YQ_MOCK'
 #!/usr/bin/env bash
 echo "yq $*" >> "${MOCK_CALLS_DIR}/yq_calls.log"
@@ -75,6 +75,123 @@ YQ_MOCK
   update_file "helmrelease.yaml" "spec.values.workload.container.image" "$IMAGE"
   grep -q ".spec.values.workload.container.image.tag=\"${INPUT_TAG}\"" "${TEST_TEMP_DIR}/yq_calls.log"
   ! grep -q "${IMAGE}" "${TEST_TEMP_DIR}/yq_calls.log"
+}
+
+# --- Integration tests using real yq ---
+
+@test "INTEGRATION: map with repository+tag preserves structure and updates tag" {
+  skip_if_no_yq
+  rm -rf "${TEST_TEMP_DIR}/mocks"
+  local test_file="${TEST_TEMP_DIR}/helmrelease.yaml"
+  cat > "$test_file" << 'EOF'
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: test-svc
+  annotations: {}
+spec:
+  values:
+    workload:
+      container:
+        image:
+          repository: registry.example.com/my-image
+          tag: old-tag
+EOF
+
+  update_file "$test_file" "spec.values.workload.container.image" "$IMAGE"
+
+  run yq '.spec.values.workload.container.image.tag' "$test_file"
+  assert_output "$INPUT_TAG"
+
+  run yq '.spec.values.workload.container.image.repository' "$test_file"
+  assert_output "registry.example.com/my-image"
+
+  run yq '.spec.values.workload.container.image | type' "$test_file"
+  assert_output "!!map"
+}
+
+@test "INTEGRATION: map with only repository gets tag added" {
+  skip_if_no_yq
+  rm -rf "${TEST_TEMP_DIR}/mocks"
+  local test_file="${TEST_TEMP_DIR}/helmrelease.yaml"
+  cat > "$test_file" << 'EOF'
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: test-svc
+  annotations: {}
+spec:
+  values:
+    workload:
+      container:
+        image:
+          repository: registry.example.com/my-image
+EOF
+
+  update_file "$test_file" "spec.values.workload.container.image" "$IMAGE"
+
+  run yq '.spec.values.workload.container.image.tag' "$test_file"
+  assert_output "$INPUT_TAG"
+
+  run yq '.spec.values.workload.container.image.repository' "$test_file"
+  assert_output "registry.example.com/my-image"
+
+  run yq '.spec.values.workload.container.image | type' "$test_file"
+  assert_output "!!map"
+}
+
+@test "INTEGRATION: map with only tag updates tag" {
+  skip_if_no_yq
+  rm -rf "${TEST_TEMP_DIR}/mocks"
+  local test_file="${TEST_TEMP_DIR}/helmrelease.yaml"
+  cat > "$test_file" << 'EOF'
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: test-svc
+  annotations: {}
+spec:
+  values:
+    workload:
+      container:
+        image:
+          tag: old-tag
+EOF
+
+  update_file "$test_file" "spec.values.workload.container.image" "$IMAGE"
+
+  run yq '.spec.values.workload.container.image.tag' "$test_file"
+  assert_output "$INPUT_TAG"
+
+  run yq '.spec.values.workload.container.image | type' "$test_file"
+  assert_output "!!map"
+}
+
+@test "INTEGRATION: scalar image field gets full URI" {
+  skip_if_no_yq
+  rm -rf "${TEST_TEMP_DIR}/mocks"
+  local test_file="${TEST_TEMP_DIR}/deployment.yaml"
+  cat > "$test_file" << 'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-svc
+  annotations: {}
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: registry.example.com/old-image:old-tag
+EOF
+
+  update_file "$test_file" 'spec.template.spec.containers[0].image' "$IMAGE"
+
+  run yq '.spec.template.spec.containers[0].image' "$test_file"
+  assert_output "$IMAGE"
+
+  run yq '.spec.template.spec.containers[0].image | type' "$test_file"
+  assert_output "!!str"
 }
 
 @test "update_file writes tag only when field path ends with .tag" {

--- a/tests/lib-gitops-functions.bats
+++ b/tests/lib-gitops-functions.bats
@@ -80,8 +80,8 @@ YQ_MOCK
 # --- Integration tests using real yq ---
 
 @test "INTEGRATION: map with only repository gets tag added" {
-  skip_if_no_yq
   rm -rf "${TEST_TEMP_DIR}/mocks"
+  skip_if_no_yq
   local test_file="${TEST_TEMP_DIR}/helmrelease.yaml"
   cat > "$test_file" << 'EOF'
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/tests/lib-gitops-functions.bats
+++ b/tests/lib-gitops-functions.bats
@@ -79,37 +79,6 @@ YQ_MOCK
 
 # --- Integration tests using real yq ---
 
-@test "INTEGRATION: map with repository+tag preserves structure and updates tag" {
-  skip_if_no_yq
-  rm -rf "${TEST_TEMP_DIR}/mocks"
-  local test_file="${TEST_TEMP_DIR}/helmrelease.yaml"
-  cat > "$test_file" << 'EOF'
-apiVersion: helm.toolkit.fluxcd.io/v2
-kind: HelmRelease
-metadata:
-  name: test-svc
-  annotations: {}
-spec:
-  values:
-    workload:
-      container:
-        image:
-          repository: registry.example.com/my-image
-          tag: old-tag
-EOF
-
-  update_file "$test_file" "spec.values.workload.container.image" "$IMAGE"
-
-  run yq '.spec.values.workload.container.image.tag' "$test_file"
-  assert_output "$INPUT_TAG"
-
-  run yq '.spec.values.workload.container.image.repository' "$test_file"
-  assert_output "registry.example.com/my-image"
-
-  run yq '.spec.values.workload.container.image | type' "$test_file"
-  assert_output "!!map"
-}
-
 @test "INTEGRATION: map with only repository gets tag added" {
   skip_if_no_yq
   rm -rf "${TEST_TEMP_DIR}/mocks"
@@ -138,60 +107,6 @@ EOF
 
   run yq '.spec.values.workload.container.image | type' "$test_file"
   assert_output "!!map"
-}
-
-@test "INTEGRATION: map with only tag updates tag" {
-  skip_if_no_yq
-  rm -rf "${TEST_TEMP_DIR}/mocks"
-  local test_file="${TEST_TEMP_DIR}/helmrelease.yaml"
-  cat > "$test_file" << 'EOF'
-apiVersion: helm.toolkit.fluxcd.io/v2
-kind: HelmRelease
-metadata:
-  name: test-svc
-  annotations: {}
-spec:
-  values:
-    workload:
-      container:
-        image:
-          tag: old-tag
-EOF
-
-  update_file "$test_file" "spec.values.workload.container.image" "$IMAGE"
-
-  run yq '.spec.values.workload.container.image.tag' "$test_file"
-  assert_output "$INPUT_TAG"
-
-  run yq '.spec.values.workload.container.image | type' "$test_file"
-  assert_output "!!map"
-}
-
-@test "INTEGRATION: scalar image field gets full URI" {
-  skip_if_no_yq
-  rm -rf "${TEST_TEMP_DIR}/mocks"
-  local test_file="${TEST_TEMP_DIR}/deployment.yaml"
-  cat > "$test_file" << 'EOF'
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: test-svc
-  annotations: {}
-spec:
-  template:
-    spec:
-      containers:
-        - name: app
-          image: registry.example.com/old-image:old-tag
-EOF
-
-  update_file "$test_file" 'spec.template.spec.containers[0].image' "$IMAGE"
-
-  run yq '.spec.template.spec.containers[0].image' "$test_file"
-  assert_output "$IMAGE"
-
-  run yq '.spec.template.spec.containers[0].image | type' "$test_file"
-  assert_output "!!str"
 }
 
 @test "update_file writes tag only when field path ends with .tag" {

--- a/tests/test_helper/setup.bash
+++ b/tests/test_helper/setup.bash
@@ -15,6 +15,12 @@ teardown_common() {
   rm -rf "$TEST_TEMP_DIR"
 }
 
+skip_if_no_yq() {
+  if ! command -v yq &> /dev/null; then
+    skip "yq not installed"
+  fi
+}
+
 # Assert that a specific output was written to GITHUB_OUTPUT
 assert_output_value() {
   local name="$1"


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [x] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

The action would currently still replace the image and not the tag. 
Added some tests using the right yq and not a mocked one to verify the behavior. 

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [X] Review the [Contributing Guideline](../blob/master/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
