### PR TITLE
feat(gitops): annotate-only mode for Flux image automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,33 @@ Whenever the action updates a GitOps file, it stamps the following annotations o
 
 These keys mirror the [Swarmia Deployment API](https://help.swarmia.com/settings/organization/configuring-deployments-in-swarmia) field names and are read by `flux-deployment-reporter` to report deployments to Swarmia once Flux finishes reconciling.
 
+### Annotate-only mode (Flux image automation)
+
+Each `gitops-dev`/`gitops-stage`/`gitops-prod` line is normally `<path> <field>`, where
+`<field>` is the yq path of the image reference to update. **Omit the field** (provide a
+path only) and the action will write the `deploy.staffbase.com/*` annotations **without
+touching the image tag**:
+
+```yaml
+gitops-stage: |-
+  kubernetes/namespaces/my-service/stage/de1/my-service-helm.yaml
+```
+
+Use this for apps whose image tag is owned by
+[Flux image automation](https://fluxcd.io/flux/components/image/) (ImageRepository /
+ImagePolicy / ImageUpdateAutomation), which scans the registry and commits the `tag:`
+line back to the GitOps repo itself. The action still needs to stamp the annotations,
+because image automation only knows the tag — it never knows the source `commitSha` or
+`repositoryFullName` that Swarmia needs for DORA metrics. This also yields a full commit
+SHA in every environment, including prod, where image tags (e.g. `2025.50.14`) carry no SHA.
+
+> **Note:** the `version` annotation is set to the freshly built tag, so it may briefly
+> lead the actual `tag:` until image automation selects the new build. It converges, and
+> the reporter dedupes on `(commitSha, version)`, so it self-heals.
+
+The two-token `<path> <field>` form is unchanged: it updates the image **and** writes the
+annotations, exactly as before.
+
 ## Inputs
 
 | Name                        | Description                                                                                                                    | Default                                              |
@@ -143,9 +170,9 @@ These keys mirror the [Swarmia Deployment API](https://help.swarmia.com/settings
 | `gitops-user`               | GitHub User for GitOps                                                                                                         | `Staffbot`                                           |
 | `gitops-email`              | GitHub Email for GitOps                                                                                                        | `staffbot@staffbase.com`                             |
 | `gitops-token`              | GitHub Token for GitOps                                                                                                        |                                                      |
-| `gitops-dev`                | Files which should be updated by the GitHub Action for DEV, must be relative to the root of the GitOps repository              |                                                      |
-| `gitops-stage`              | Files which should be updated by the GitHub Action for STAGE, must be relative to the root of the GitOps repository            |                                                      |
-| `gitops-prod`               | Files which should be updated by the GitHub Action for PROD, must be relative to the root of the GitOps repository             |                                                      |
+| `gitops-dev`                | Files which should be updated by the GitHub Action for DEV, must be relative to the root of the GitOps repository. Each line is `<path> <field>`; omit `<field>` (path only) to write annotations without touching the image — see [Annotate-only mode](#annotate-only-mode-flux-image-automation) |                                                      |
+| `gitops-stage`              | Files which should be updated by the GitHub Action for STAGE, must be relative to the root of the GitOps repository. Each line is `<path> <field>`; omit `<field>` (path only) for [annotate-only mode](#annotate-only-mode-flux-image-automation) |                                                      |
+| `gitops-prod`               | Files which should be updated by the GitHub Action for PROD, must be relative to the root of the GitOps repository. Each line is `<path> <field>`; omit `<field>` (path only) for [annotate-only mode](#annotate-only-mode-flux-image-automation) |                                                      |
 | `working-directory`         | The directory in which the GitOps action should be executed. The docker-file variable should be relative to working directory. | `.`                                                  |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ annotations, exactly as before.
 | `docker-build-target`       | Sets the target stage to build like: "runtime"                                                                                 |                                                      |
 | `docker-build-platforms`       | Sets the target platforms for build                                                                                 | linux/amd64 |
 | `docker-build-provenance`   | Generate [provenance](https://docs.docker.com/build/attestations/slsa-provenance/) attestation for the build                   | `false`                                              |
+| `docker-build-outputs`      | Custom output destinations (e.g. `type=registry,push=true,compression=zstd,force-compression=true`). When set, this replaces the default push behavior — include `push=true` if pushing is desired |                                          |
 | `docker-disable-retagging`  | Disables retagging of existing images and run a new build instead                                                              | `false`                                              |
 | `gitops-organization`       | GitHub Organization for GitOps                                                                                                 | `Staffbase`                                          |
 | `gitops-repository`         | GitHub Repository for GitOps                                                                                                   | `mops`                                               |
@@ -173,6 +174,9 @@ annotations, exactly as before.
 | `gitops-dev`                | Files which should be updated by the GitHub Action for DEV, must be relative to the root of the GitOps repository. Each line is `<path> <field>`; omit `<field>` (path only) to write annotations without touching the image — see [Annotate-only mode](#annotate-only-mode-flux-image-automation) |                                                      |
 | `gitops-stage`              | Files which should be updated by the GitHub Action for STAGE, must be relative to the root of the GitOps repository. Each line is `<path> <field>`; omit `<field>` (path only) for [annotate-only mode](#annotate-only-mode-flux-image-automation) |                                                      |
 | `gitops-prod`               | Files which should be updated by the GitHub Action for PROD, must be relative to the root of the GitOps repository. Each line is `<path> <field>`; omit `<field>` (path only) for [annotate-only mode](#annotate-only-mode-flux-image-automation) |                                                      |
+| `upwind-client-id`          | Upwind Client ID                                                                                                              |                                                      |
+| `upwind-organization-id`    | Upwind Organization ID                                                                                                        |                                                      |
+| `upwind-client-secret`      | Upwind Client Secret                                                                                                          |                                                      |
 | `working-directory`         | The directory in which the GitOps action should be executed. The docker-file variable should be relative to working directory. | `.`                                                  |
 
 ## Outputs

--- a/scripts/lib/gitops-functions.sh
+++ b/scripts/lib/gitops-functions.sh
@@ -33,19 +33,23 @@ update_file() {
   local field="$2"
   local image="$3"
 
-  echo "Check if path ${file} ${field} exists and get old current version"
-  yq -e ."${field}" "${file}"
-  echo "Run update ${file} ${field} ${image}"
-  if [[ "${field}" == *.tag ]]; then
-    yq -i ".${field}=\"${INPUT_TAG}\"" "${file}"
-  else
-    local field_type
-    field_type=$(yq "(.${field} | type)" "${file}" 2>/dev/null || echo "!!null")
-    if [[ "${field_type}" == "!!map" ]] && yq -e ".${field} | (has(\"tag\") or has(\"repository\"))" "${file}" > /dev/null 2>&1; then
-      yq -i ".${field}.tag=\"${INPUT_TAG}\"" "${file}"
+  if [[ -n "$field" ]]; then
+    echo "Check if path ${file} ${field} exists and get old current version"
+    yq -e ."${field}" "${file}"
+    echo "Run update ${file} ${field} ${image}"
+    if [[ "${field}" == *.tag ]]; then
+      yq -i ".${field}=\"${INPUT_TAG}\"" "${file}"
     else
-      yq -i ."${field}"=\""${image}"\" "${file}"
+      local field_type
+      field_type=$(yq "(.${field} | type)" "${file}" 2>/dev/null || echo "!!null")
+      if [[ "${field_type}" == "!!map" ]] && yq -e ".${field} | (has(\"tag\") or has(\"repository\"))" "${file}" > /dev/null 2>&1; then
+        yq -i ".${field}.tag=\"${INPUT_TAG}\"" "${file}"
+      else
+        yq -i ."${field}"=\""${image}"\" "${file}"
+      fi
     fi
+  else
+    echo "No field for ${file}; image tag owned by Flux image automation — writing annotations only"
   fi
 
   echo "Writing deployment annotations to ${file}"

--- a/tests/lib-gitops-functions.bats
+++ b/tests/lib-gitops-functions.bats
@@ -147,6 +147,63 @@ EOF
   ! grep -qE 'deploy\.staffbase\.com/(repo|sha)"' "${TEST_TEMP_DIR}/yq_calls.log"
 }
 
+# --- update_file: annotate-only mode (empty field) ---
+
+@test "update_file with empty field skips image update" {
+  update_file "helmrelease.yaml" "" ""
+  # the field-existence check (yq -e .<field>) only runs in field mode
+  ! grep -q 'yq -e .' "${TEST_TEMP_DIR}/yq_calls.log"
+  # no image/tag assignment written
+  ! grep -qE 'yq -i \.[^ ]*=' "${TEST_TEMP_DIR}/yq_calls.log"
+}
+
+@test "update_file with empty field still writes all three annotations" {
+  update_file "helmrelease.yaml" "" ""
+  grep -q 'deploy.staffbase.com/repositoryFullName' "${TEST_TEMP_DIR}/yq_calls.log"
+  grep -q 'deploy.staffbase.com/commitSha' "${TEST_TEMP_DIR}/yq_calls.log"
+  grep -q "deploy.staffbase.com/version.*${INPUT_TAG}" "${TEST_TEMP_DIR}/yq_calls.log"
+}
+
+@test "INTEGRATION: empty field annotates without touching the image tag" {
+  rm -rf "${TEST_TEMP_DIR}/mocks"
+  skip_if_no_yq
+  local test_file="${TEST_TEMP_DIR}/helmrelease.yaml"
+  cp "${BATS_TEST_DIRNAME}/fixtures/helmrelease.yaml" "$test_file"
+
+  update_file "$test_file" "" ""
+
+  # image tag is unchanged
+  run yq '.spec.values.workload.container.image.tag' "$test_file"
+  assert_output "placeholder"
+
+  # annotations are stamped
+  run yq '.metadata.annotations["deploy.staffbase.com/repositoryFullName"]' "$test_file"
+  assert_output "$GITHUB_REPOSITORY"
+  run yq '.metadata.annotations["deploy.staffbase.com/commitSha"]' "$test_file"
+  assert_output "$GITHUB_SHA"
+  run yq '.metadata.annotations["deploy.staffbase.com/version"]' "$test_file"
+  assert_output "$INPUT_TAG"
+}
+
+@test "INTEGRATION: provided field updates the tag AND annotates" {
+  rm -rf "${TEST_TEMP_DIR}/mocks"
+  skip_if_no_yq
+  local test_file="${TEST_TEMP_DIR}/helmrelease.yaml"
+  cp "${BATS_TEST_DIRNAME}/fixtures/helmrelease.yaml" "$test_file"
+
+  update_file "$test_file" "spec.values.workload.container.image" "$IMAGE"
+
+  # image tag updated
+  run yq '.spec.values.workload.container.image.tag' "$test_file"
+  assert_output "$INPUT_TAG"
+
+  # annotations also stamped
+  run yq '.metadata.annotations["deploy.staffbase.com/commitSha"]' "$test_file"
+  assert_output "$GITHUB_SHA"
+  run yq '.metadata.annotations["deploy.staffbase.com/version"]' "$test_file"
+  assert_output "$INPUT_TAG"
+}
+
 # --- commit_changes ---
 
 @test "commit_changes commits and pushes when push is true" {
@@ -194,6 +251,13 @@ file2.yaml spec.image"
   local yq_count
   yq_count=$(grep -c 'yq -e' "${TEST_TEMP_DIR}/yq_calls.log")
   [[ "$yq_count" -eq 2 ]]
+}
+
+@test "process_file_updates handles path-only line (annotate only)" {
+  process_file_updates "file1.yaml" "false"
+  # no field check performed, but annotations written
+  ! grep -q 'yq -e .' "${TEST_TEMP_DIR}/yq_calls.log"
+  grep -q 'deploy.staffbase.com/commitSha' "${TEST_TEMP_DIR}/yq_calls.log"
 }
 
 @test "process_file_updates commits when should_commit is true" {


### PR DESCRIPTION
## What

Adds an **annotate-only mode** to `update_file`: when a `gitops-dev`/`gitops-stage`/`gitops-prod` line provides a **path only (no field)**, the action writes the `deploy.staffbase.com/*` annotations **without updating the image tag**.

The image-update block is now guarded on a non-empty `field`; the annotation writes stay unconditional. The line parser already leaves `field` empty for a path-only line, so no parser change was needed.

```yaml
# annotate only — image tag owned by Flux image automation
gitops-stage: |-
  kubernetes/namespaces/my-service/stage/de1/my-service-helm.yaml
```

## Why

Staffbase is migrating apps from the **apperator `Application` CR** to the **`staffbase-application` Helm chart** (HelmRelease overlays in `mops`). In the new model the image tag is owned by **Flux image automation** (ImageRepository/ImagePolicy/ImageUpdateAutomation), which scans the registry and commits the `tag:` line back to `mops` itself.

So for migrated apps this action must **stop writing the tag** — but must **keep writing the annotations**. `flux-deployment-reporter` reads `commitSha` + `repositoryFullName` off the reconciled resource to report deployments to Swarmia for DORA metrics, and those are build-time facts only this action knows (image automation only ever knows the tag, never the source commit/repo). Keeping this action as the annotation-writer also yields a full commit SHA in **every** environment, including prod, where tags are CalVer (`2025.50.14`) and carry no SHA.

### Known transient skew
`version` is still set to `INPUT_TAG` (the freshly built tag). It may briefly **lead** the actual `tag:` until image automation selects the new build. It converges, and the reporter dedupes on `(commitSha, version)`, so it self-heals.

## Backward compatibility

The two-token `<path> <field>` form is **unchanged** — image update **and** annotations, exactly as today. Apperator apps still mid-migration keep working. No new required input; the path-only line is the trigger.

## Tests

- `update_file` with empty field: skips image update, still writes all three annotations (mock + real-`yq` integration on the `helmrelease.yaml` fixture, asserting the `tag:` is untouched).
- `update_file` with field: regression test that the tag is updated **and** annotations written.
- `process_file_updates` path-only line end-to-end.
- Full suite green (84 tests), shellcheck clean.

## Out of scope

The reporter change to list **HelmRelease** (`helm.toolkit.fluxcd.io/v2`) in addition to the apperator `Application` CR is handled separately in the `flux-deployment-reporter` repo — the annotation keys/values are identical regardless of resource kind, so no change is needed here.

## Dependency

* https://github.com/Staffbase/flux-deployment-reporter/pull/41